### PR TITLE
allow running app outside of exc shell and only set url prefix for exc shell in exc template

### DIFF
--- a/generators/add-web-assets/exc-react/index.js
+++ b/generators/add-web-assets/exc-react/index.js
@@ -13,7 +13,7 @@ const path = require('path')
 const Generator = require('yeoman-generator')
 const utils = require('../../../lib/utils')
 
-const { webAssetsDirname } = require('../../../lib/constants')
+const { webAssetsDirname, dotenvFilename } = require('../../../lib/constants')
 const { sdkCodes } = require('../../../lib/constants')
 
 class ExcReactGenerator extends Generator {
@@ -43,6 +43,9 @@ class ExcReactGenerator extends Generator {
       'react-dom': '^16.9.0',
       'react-error-boundary': '^1.2.5'
     })
+    // add env variable to load ui in exc shell
+    utils.appendOrWrite(this, this.destinationPath(dotenvFilename),
+      'AIO_LAUNCH_URL_PREFIX=https://experience.adobe.com/?devMode=true#/myapps/?localDevUrl=')
   }
 
   async install () {

--- a/generators/add-web-assets/exc-react/index.js
+++ b/generators/add-web-assets/exc-react/index.js
@@ -45,7 +45,7 @@ class ExcReactGenerator extends Generator {
     })
     // add env variable to load ui in exc shell
     utils.appendOrWrite(this, this.destinationPath(dotenvFilename),
-      'AIO_LAUNCH_URL_PREFIX=https://experience.adobe.com/?devMode=true#/myapps/?localDevUrl=')
+      'AIO_LAUNCH_URL_PREFIX="https://experience.adobe.com/?devMode=true#/myapps/?localDevUrl="')
   }
 
   async install () {

--- a/generators/add-web-assets/exc-react/templates/src/exc-runtime.js
+++ b/generators/add-web-assets/exc-react/templates/src/exc-runtime.js
@@ -1,3 +1,12 @@
-/*  */
+/* <% if (false) { %>
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+<% } %> */
 /* eslint-disable-next-line */
 module.exports = function(e,t){if(t.location===t.parent.location)throw new Error("Module Runtime: Needs to be within an iframe!");var o=function(e){var t=new URL(e.location.href).searchParams.get("_mr");return t||!e.EXC_US_HMR?t:e.sessionStorage.getItem("unifiedShellMRScript")}(t);if(!o)throw new Error("Module Runtime: Missing script!");if("https:"!==(o=new URL(decodeURIComponent(o))).protocol)throw new Error("Module Runtime: Must be HTTPS!");if(!/experience(-qa|-stage)?\.adobe\.com$/.test(o.hostname)&&!/localhost\.corp\.adobe\.com$/.test(o.hostname))throw new Error("Module Runtime: Invalid domain!");if(!/\.js$/.test(o.pathname))throw new Error("Module Runtime: Must be a JavaScript file!");t.EXC_US_HMR&&t.sessionStorage.setItem("unifiedShellMRScript",o.toString());var n=e.createElement("script");n.async=1,n.src=o.toString(),n.onload=n.onreadystatechange=function(){n.readyState&&!/loaded|complete/.test(n.readyState)||(n.onload=n.onreadystatechange=null,n=void 0,"EXC_MR_READY"in t&&t.EXC_MR_READY())},e.head.appendChild(n)};

--- a/generators/add-web-assets/exc-react/templates/src/exc-runtime.js
+++ b/generators/add-web-assets/exc-react/templates/src/exc-runtime.js
@@ -1,18 +1,3 @@
-/* <% if (false) { %>
-Copyright 2019 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License. You may obtain a copy
-of the License at http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software distributed under
-the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-OF ANY KIND, either express or implied. See the License for the specific language
-governing permissions and limitations under the License.
-<% } %> */
+/*  */
 /* eslint-disable-next-line */
-try {
-  (function(e,t){if(t.location===t.parent.location)throw new Error("Module Runtime: Needs to be within an iframe!");var o=function(e){var t=new URL(e.location.href).searchParams.get("_mr");return t||!e.EXC_US_HMR?t:e.sessionStorage.getItem("unifiedShellMRScript")}(t);if(!o)throw new Error("Module Runtime: Missing script!");if("https:"!==(o=new URL(decodeURIComponent(o))).protocol)throw new Error("Module Runtime: Must be HTTPS!");if(!/experience(-qa|-stage)?\.adobe\.com$/.test(o.hostname)&&!/localhost\.corp\.adobe\.com$/.test(o.hostname))throw new Error("Module Runtime: Invalid domain!");if(!/\.js$/.test(o.pathname))throw new Error("Module Runtime: Must be a JavaScript file!");t.EXC_US_HMR&&t.sessionStorage.setItem("unifiedShellMRScript",o.toString());var n=e.createElement("script");n.async=1,n.src=o.toString(),n.onload=n.onreadystatechange=function(){n.readyState&&!/loaded|complete/.test(n.readyState)||(n.onload=n.onreadystatechange=null,n=void 0,"EXC_MR_READY"in t&&t.EXC_MR_READY())},e.head.appendChild(n)})(document,window);
-} catch (e) {
-  // show an error message if the application wasn't loaded in the Adobe Experience Cloud Shell iframe
-  console.error('could not load exc runtime,', e)
-  document.body.innerText = 'Error: this application must run in the exc-shell'
-}
+module.exports = function(e,t){if(t.location===t.parent.location)throw new Error("Module Runtime: Needs to be within an iframe!");var o=function(e){var t=new URL(e.location.href).searchParams.get("_mr");return t||!e.EXC_US_HMR?t:e.sessionStorage.getItem("unifiedShellMRScript")}(t);if(!o)throw new Error("Module Runtime: Missing script!");if("https:"!==(o=new URL(decodeURIComponent(o))).protocol)throw new Error("Module Runtime: Must be HTTPS!");if(!/experience(-qa|-stage)?\.adobe\.com$/.test(o.hostname)&&!/localhost\.corp\.adobe\.com$/.test(o.hostname))throw new Error("Module Runtime: Invalid domain!");if(!/\.js$/.test(o.pathname))throw new Error("Module Runtime: Must be a JavaScript file!");t.EXC_US_HMR&&t.sessionStorage.setItem("unifiedShellMRScript",o.toString());var n=e.createElement("script");n.async=1,n.src=o.toString(),n.onload=n.onreadystatechange=function(){n.readyState&&!/loaded|complete/.test(n.readyState)||(n.onload=n.onreadystatechange=null,n=void 0,"EXC_MR_READY"in t&&t.EXC_MR_READY())},e.head.appendChild(n)};

--- a/generators/add-web-assets/exc-react/templates/src/index.js
+++ b/generators/add-web-assets/exc-react/templates/src/index.js
@@ -12,19 +12,40 @@ import config from './config.json'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './App'
+import loadExcRuntime from './exc-runtime'
 
 /* Here you can bootstrap your application and configure the integration with the Adobe Experience Cloud Shell */
-
-// this piece of code is needed in case the Adobe Experience Cloud shell runtime is not yet loaded.
-// if it is ready we bootstrap the app, otherwise we defer the bootstrapping to the exc runtime when it is ready.
-if ('exc-module-runtime' in window) {
-  bootstrap()
-} else {
-  // callback for the exc shell runtime, if not ready yet
-  window.EXC_MR_READY = () => bootstrap()
+let inExc = false
+try {
+  // throws if not running in exc
+  loadExcRuntime(document, window)
+  inExc = true
+} catch (e) {
+  console.log('application not running in Adobe Experience Cloud Shell')
+  // fallback, not in exc run the UI without the shell
+  bootstrapRaw()
 }
 
-function bootstrap () {
+if (inExc) {
+  // this piece of code is needed in case the Adobe Experience Cloud shell runtime is not yet loaded.
+  // if it is ready we bootstrap the app, otherwise we defer the bootstrapping to the exc runtime when it is ready.
+  if ('exc-module-runtime' in window) {
+    bootstrapInExcShell()
+  } else {
+    // callback for the exc shell runtime, if not ready yet
+    window.EXC_MR_READY = () => bootstrapInExcShell()
+  }
+}
+
+function bootstrapRaw () {
+  /* **here you can mock the exc runtime object** */
+  const runtime = {}
+
+  // render the actual react application and pass along the runtime object to make it available to the App
+  ReactDOM.render(<App runtime={runtime}/>, document.getElementById('root'))
+}
+
+function bootstrapInExcShell () {
   // initializes the runtime object
   const Runtime = window['exc-module-runtime'].default
   const runtime = new Runtime({

--- a/generators/app/templates/_dot.env
+++ b/generators/app/templates/_dot.env
@@ -5,5 +5,3 @@
 ## please provide your Adobe I/O Runtime credentials
 # AIO_RUNTIME_AUTH=
 # AIO_RUNTIME_NAMESPACE=
-
-AIO_LAUNCH_URL_PREFIX=https://experience.adobe.com/?devMode=true#/myapps/?localDevUrl=

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,8 +22,16 @@ function addDependencies (generator, deps, dev = false) {
   generator.fs.writeJSON(packagejsonPath, packagejsonContent)
 }
 
+function appendOrWrite (generator, file, content) {
+  if (generator.fs.exists(file)) {
+    return generator.fs.append(file, content)
+  }
+  return generator.fs.write(file, content)
+}
+
 module.exports = {
   atLeastOne,
   guessProjectName,
-  addDependencies
+  addDependencies,
+  appendOrWrite
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/adobe/generator-aio-app#readme",
   "devDependencies": {
     "@types/jest": "^25.1.0",
+    "codecov": "^3.6.5",
     "eslint": "^6.7.2",
     "eslint-config-standard": "^14.1.0",
     "eslint-plugin-import": "^2.19.1",
@@ -39,7 +40,6 @@
     "yeoman-test": "^2.0.0"
   },
   "dependencies": {
-    "codecov": "^3.6.1",
     "fs-extra": "^8.1.0",
     "js-yaml": "^3.13.1",
     "yeoman-generator": "^4.2.0"

--- a/test/generators/add-web-assets/exc-react.test.js
+++ b/test/generators/add-web-assets/exc-react.test.js
@@ -13,6 +13,8 @@ governing permissions and limitations under the License.
 
 const helpers = require('yeoman-test')
 const assert = require('yeoman-assert')
+const fs = require('fs')
+const path = require('path')
 
 const theGeneratorPath = require.resolve('../../../generators/add-web-assets/exc-react')
 const Generator = require('yeoman-generator')
@@ -39,6 +41,9 @@ describe('run', () => {
   test('--project-name abc', async () => {
     await helpers.run(theGeneratorPath)
       .withOptions({ 'project-name': 'abc', 'skip-install': false })
+      .inTmpDir(dir => {
+        fs.writeFileSync(path.join(dir, '.env'), 'FAKECONTENT')
+      })
 
     // added files
     assert.file('web-src/index.html')
@@ -46,6 +51,11 @@ describe('run', () => {
     assert.file('web-src/src/index.js')
     assert.file('web-src/src/App.js')
     assert.file('web-src/src/exc-runtime.js')
+
+    // check append to dotenv
+    assert.file('.env')
+    assert.fileContent('.env', 'FAKECONTENT')
+    assert.fileContent('.env', 'AIO_LAUNCH_URL_PREFIX=https://experience.adobe.com/?devMode=true#/myapps/?localDevUrl=')
 
     // make sure react dependencies are added
     assert.jsonFileContent('package.json', {

--- a/test/generators/add-web-assets/exc-react.test.js
+++ b/test/generators/add-web-assets/exc-react.test.js
@@ -55,7 +55,7 @@ describe('run', () => {
     // check append to dotenv
     assert.file('.env')
     assert.fileContent('.env', 'FAKECONTENT')
-    assert.fileContent('.env', 'AIO_LAUNCH_URL_PREFIX=https://experience.adobe.com/?devMode=true#/myapps/?localDevUrl=')
+    assert.fileContent('.env', 'AIO_LAUNCH_URL_PREFIX="https://experience.adobe.com/?devMode=true#/myapps/?localDevUrl="')
 
     // make sure react dependencies are added
     assert.jsonFileContent('package.json', {

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -9,6 +9,40 @@ describe('atLeastOne', () => {
   })
 })
 
+describe('appendOrWrite', () => {
+  test('writes if file does not exist', () => {
+    const mockWrite = jest.fn()
+    const mockAppend = jest.fn()
+    const generator = {
+      fs: {
+        exists: () => false,
+        write: mockWrite,
+        append: mockAppend
+      }
+    }
+    utils.appendOrWrite(generator, 'file', 'content')
+    expect(mockWrite).toHaveBeenCalledTimes(1)
+    expect(mockWrite).toHaveBeenCalledWith('file', 'content')
+    expect(mockAppend).toHaveBeenCalledTimes(0)
+  })
+
+  test('appends if file exists', () => {
+    const mockWrite = jest.fn()
+    const mockAppend = jest.fn()
+    const generator = {
+      fs: {
+        exists: () => true,
+        write: mockWrite,
+        append: mockAppend
+      }
+    }
+    utils.appendOrWrite(generator, 'file', 'content')
+    expect(mockAppend).toHaveBeenCalledTimes(1)
+    expect(mockAppend).toHaveBeenCalledWith('file', 'content')
+    expect(mockWrite).toHaveBeenCalledTimes(0)
+  })
+})
+
 describe('guessProjectName', () => {
   test('returns cwd if package.json does not exist', () => {
     const spy = jest.spyOn(process, 'cwd')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- allow to run UI outside of exc shell
- only add exc env var url prefix in exc ui template, i.e. no need to add this env var for action only projects + add missing tests + quotes around env var

<!--- Describe your changes in detail -->
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
