### PR TITLE
Added generator to delete event similar to delete action

### DIFF
--- a/generators/delete-events/index.js
+++ b/generators/delete-events/index.js
@@ -1,0 +1,96 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const Generator = require('yeoman-generator')
+const path = require('path')
+const fs = require('fs-extra')
+const yaml = require('js-yaml')
+
+const { manifestPackagePlaceholder, actionsDirname } = require('../../lib/constants')
+
+/*
+      'initializing',
+      'prompting',
+      'configuring',
+      'default',
+      'writing',
+      'conflicts',
+      'install',
+      'end'
+      */
+
+class DeleteEvents extends Generator {
+  constructor (args, opts) {
+    super(args, opts)
+
+    // options are inputs from CLI or yeoman parent generator
+    this.option('skip-prompt', { default: false })
+    this.option('action-name', { type: String, default: '' })
+  }
+
+  initializing () {
+    if (this.options['skip-prompt'] && !this.options['action-name']) {
+      throw new Error('--skip-prompt option provided but missing --action-name')
+    }
+
+    this.manifestContent = fs.existsSync(this.destinationPath('manifest.yml')) && yaml.safeLoad(fs.readFileSync(this.destinationPath('manifest.yml')).toString())
+    this.manifestActions = this.manifestContent && this.manifestContent.packages[manifestPackagePlaceholder].actions
+    if (!this.manifestContent || Object.keys(this.manifestActions).length === 0) throw new Error('you have no actions in your project')
+  }
+
+  async prompting () {
+    this.actionName = this.options['action-name']
+    if (!this.actionName) {
+      const resAction = await this.prompt([
+        {
+          type: 'list',
+          name: 'actionName',
+          message: 'Which action do you whish to delete from the project?\nselect action to delete',
+          choices: Object.keys(this.manifestActions),
+          when: !this.options['skip-prompt'] && !this.options['action-name']
+        }
+      ])
+      this.actionName = resAction.actionName
+    }
+
+    if (!this.manifestActions[this.actionName]) {
+      throw new Error(`action name '${this.actionName}' does not exist`)
+    }
+  }
+
+  async end () {
+    const resConfirm = await this.prompt([
+      {
+        type: 'confirm',
+        name: 'deleteEventAction',
+        message: `Please confirm the deletion of the event action '${this.actionName}' and all its source code`,
+        when: !this.options['skip-prompt']
+      }
+    ])
+    if (this.options['skip-prompt'] || resConfirm.deleteEventAction) {
+      this.log(`> deleting action '${this.actionName}', please make sure to cleanup associated dependencies and configurations yourself`)
+
+      this.actionPath = this.destinationPath(this.manifestActions[this.actionName].function)
+
+      // todo how to do this using this.fs ?
+      if (fs.statSync(this.actionPath).isFile()) this.actionPath = path.dirname(this.actionPath)
+
+      fs.removeSync(this.actionPath) // will make user prompt for all files if not --force
+      delete this.manifestActions[this.actionName]
+      fs.writeFileSync(this.destinationPath('manifest.yml'), yaml.safeDump(this.manifestContent))
+
+      fs.removeSync(this.destinationPath('e2e', actionsDirname, this.actionName + '.e2e.js')) // remove e2e test
+      fs.removeSync(this.destinationPath('test', actionsDirname, this.actionName + '.test.js')) // remove unit test
+    }
+  }
+}
+
+module.exports = DeleteEvents

--- a/test/generators/delete-events/index.test.js
+++ b/test/generators/delete-events/index.test.js
@@ -1,0 +1,168 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const path = require('path')
+const fs = require('fs-extra')
+const helpers = require('yeoman-test')
+const assert = require('yeoman-assert')
+
+const theGeneratorPath = require.resolve('../../../generators/delete-events')
+const Generator = require('yeoman-generator')
+
+jest.mock('../../../lib/utils')
+
+describe('prototype', () => {
+  test('exports a yeoman generator', () => {
+    expect(require(theGeneratorPath).prototype).toBeInstanceOf(Generator)
+  })
+})
+
+describe('run', () => {
+  function writeFakeActionFile (dir, actionName, isDirPath = false) {
+    const actionContent = 'function main(){};module.exports = main'
+    const actionPath = `actions/${actionName}/index.js`
+    const manifestContent = `packages:
+  __APP_PACKAGE__:
+    actions:
+      ${actionName}:
+        function: ${isDirPath ? path.dirname(actionPath) : actionPath}
+`
+    // we use real fs, dir is provided by yeoman-test helpers and will be cleaned up
+    fs.ensureDirSync(path.join(dir, path.dirname(actionPath)))
+    fs.writeFileSync(path.join(dir, actionPath), actionContent)
+    fs.writeFileSync(path.join(dir, 'manifest.yml'), manifestContent)
+  }
+
+  test('no manifest.yml', async () => {
+    await expect(
+      helpers.run(theGeneratorPath)
+    ).rejects.toThrow('you have no actions in your project')
+  })
+
+  test('--skip-prompt is provided but not --action-name', async () => {
+    await expect(
+      helpers.run(theGeneratorPath)
+        .withOptions({ 'skip-prompt': true })
+    ).rejects.toThrow('--skip-prompt option provided but missing --action-name')
+  })
+
+  test('prompts with a non existing actionName', async () => {
+    await expect(
+      helpers.run(theGeneratorPath)
+        .inTmpDir(dir => {
+          writeFakeActionFile(dir, 'fakeName')
+        })
+        .withPrompts({ actionName: 'notexisting' })
+    ).rejects.toThrow('action name \'notexisting\' does not exist')
+  })
+
+  test('--skip-prompt --action-name=notexisting', async () => {
+    await expect(
+      helpers.run(theGeneratorPath)
+        .inTmpDir(dir => {
+          writeFakeActionFile(dir, 'fakeName')
+        })
+        .withOptions({ 'skip-prompt': true, 'action-name': 'notexisting' })
+    ).rejects.toThrow('action name \'notexisting\' does not exist')
+  })
+
+  test('prompts action name `fakeName` and prompts yes to delete confirmation', async () => {
+    await expect(
+      helpers.run(theGeneratorPath)
+        .inTmpDir(dir => {
+          writeFakeActionFile(dir, 'fakeName')
+        })
+        .withPrompts({ actionName: 'fakeName', deleteEventAction: true })
+    ).resolves.toEqual(expect.any(String))
+
+    assert.noFile('actions/fakeName/index.js')
+    assert.file('manifest.yml')
+    assert.noFileContent('manifest.yml', 'fakeName')
+    assert.noFileContent('manifest.yml', 'function: actions/fakeName/index.js')
+  })
+
+  test('prompts action name `fakeName` and prompts false to delete confirmation', async () => {
+    await expect(
+      helpers.run(theGeneratorPath)
+        .inTmpDir(dir => {
+          writeFakeActionFile(dir, 'fakeName')
+        })
+        .withPrompts({ actionName: 'fakeName', deleteEventAction: false })
+    ).resolves.toEqual(expect.any(String))
+
+    assert.file('actions/fakeName/index.js')
+    assert.file('manifest.yml')
+    assert.fileContent('manifest.yml', 'fakeName')
+    assert.fileContent('manifest.yml', 'function: actions/fakeName/index.js')
+  })
+
+  test('--action-name=fakeName and prompts yes to delete confirmation', async () => {
+    await expect(
+      helpers.run(theGeneratorPath)
+        .withOptions({ 'action-name': 'fakeName' })
+        .inTmpDir(dir => {
+          writeFakeActionFile(dir, 'fakeName')
+        })
+        .withPrompts({ deleteEventAction: true })
+    ).resolves.toEqual(expect.any(String))
+
+    assert.noFile('actions/fakeName/index.js')
+    assert.file('manifest.yml')
+    assert.noFileContent('manifest.yml', 'fakeName')
+    assert.noFileContent('manifest.yml', 'function: actions/fakeName/index.js')
+  })
+
+  test('--action-name=fakeName and prompts false to delete confirmation', async () => {
+    await expect(
+      helpers.run(theGeneratorPath)
+        .withOptions({ 'action-name': 'fakeName' })
+        .inTmpDir(dir => {
+          writeFakeActionFile(dir, 'fakeName')
+        })
+        .withPrompts({ deleteEventAction: false })
+    ).resolves.toEqual(expect.any(String))
+
+    assert.file('actions/fakeName/index.js')
+    assert.file('manifest.yml')
+    assert.fileContent('manifest.yml', 'fakeName')
+    assert.fileContent('manifest.yml', 'function: actions/fakeName/index.js')
+  })
+
+  test('--skip-prompt --action-name=fakeName', async () => {
+    await expect(
+      helpers.run(theGeneratorPath)
+        .withOptions({ 'skip-prompt': true, 'action-name': 'fakeName' })
+        .inTmpDir(dir => {
+          writeFakeActionFile(dir, 'fakeName')
+        })
+    ).resolves.toEqual(expect.any(String))
+
+    assert.noFile('actions/fakeName/index.js')
+    assert.file('manifest.yml')
+    assert.noFileContent('manifest.yml', 'fakeName')
+    assert.noFileContent('manifest.yml', 'function: actions/fakeName/index.js')
+  })
+
+  test('--skip-prompt --action-name=fakeName AND action.function points to dir in manifest', async () => {
+    await expect(
+      helpers.run(theGeneratorPath)
+        .withOptions({ 'skip-prompt': true, 'action-name': 'fakeName' })
+        .inTmpDir(dir => {
+          writeFakeActionFile(dir, 'fakeName', true)
+        })
+    ).resolves.toEqual(expect.any(String))
+
+    assert.noFile('actions/fakeName/index.js')
+    assert.file('manifest.yml')
+    assert.noFileContent('manifest.yml', 'fakeName')
+    assert.noFileContent('manifest.yml', 'function: actions/fakeName/index.js')
+  })
+})

--- a/test/generators/delete-events/index.test.js
+++ b/test/generators/delete-events/index.test.js
@@ -9,15 +9,27 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const path = require('path')
-const fs = require('fs-extra')
 const helpers = require('yeoman-test')
-const assert = require('yeoman-assert')
 
 const theGeneratorPath = require.resolve('../../../generators/delete-events')
 const Generator = require('yeoman-generator')
-
+const actionName = 'fakename'
+const prompt = jest.spyOn(Generator.prototype, 'prompt')
+const composeWith = jest.spyOn(Generator.prototype, 'composeWith')
+const expectedDefaultEventsGenerator = expect.stringContaining(n('delete-action/index.js'))
 jest.mock('../../../lib/utils')
+
+beforeAll(() => {
+  // mock implementations
+  composeWith.mockReturnValue(undefined)
+})
+beforeEach(() => {
+  prompt.mockClear()
+  composeWith.mockClear()
+})
+afterAll(() => {
+  composeWith.mockRestore()
+})
 
 describe('prototype', () => {
   test('exports a yeoman generator', () => {
@@ -26,143 +38,26 @@ describe('prototype', () => {
 })
 
 describe('run', () => {
-  function writeFakeActionFile (dir, actionName, isDirPath = false) {
-    const actionContent = 'function main(){};module.exports = main'
-    const actionPath = `actions/${actionName}/index.js`
-    const manifestContent = `packages:
-  __APP_PACKAGE__:
-    actions:
-      ${actionName}:
-        function: ${isDirPath ? path.dirname(actionPath) : actionPath}
-`
-    // we use real fs, dir is provided by yeoman-test helpers and will be cleaned up
-    fs.ensureDirSync(path.join(dir, path.dirname(actionPath)))
-    fs.writeFileSync(path.join(dir, actionPath), actionContent)
-    fs.writeFileSync(path.join(dir, 'manifest.yml'), manifestContent)
-  }
-
-  test('no manifest.yml', async () => {
-    await expect(
-      helpers.run(theGeneratorPath)
-    ).rejects.toThrow('you have no actions in your project')
+  test('--skip-prompt "', async () => {
+    await helpers.run(theGeneratorPath)
+      .withOptions({ 'skip-prompt': true })
+    // with skip prompt defaults to generic action
+    // make sure sub generators have been called
+    expect(composeWith).toHaveBeenCalledTimes(1)
+    expect(composeWith).toHaveBeenCalledWith(expectedDefaultEventsGenerator, expect.objectContaining({
+      'skip-prompt': true
+    }))
   })
 
-  test('--skip-prompt is provided but not --action-name', async () => {
-    await expect(
-      helpers.run(theGeneratorPath)
-        .withOptions({ 'skip-prompt': true })
-    ).rejects.toThrow('--skip-prompt option provided but missing --action-name')
-  })
-
-  test('prompts with a non existing actionName', async () => {
-    await expect(
-      helpers.run(theGeneratorPath)
-        .inTmpDir(dir => {
-          writeFakeActionFile(dir, 'fakeName')
-        })
-        .withPrompts({ actionName: 'notexisting' })
-    ).rejects.toThrow('action name \'notexisting\' does not exist')
-  })
-
-  test('--skip-prompt --action-name=notexisting', async () => {
-    await expect(
-      helpers.run(theGeneratorPath)
-        .inTmpDir(dir => {
-          writeFakeActionFile(dir, 'fakeName')
-        })
-        .withOptions({ 'skip-prompt': true, 'action-name': 'notexisting' })
-    ).rejects.toThrow('action name \'notexisting\' does not exist')
-  })
-
-  test('prompts action name `fakeName` and prompts yes to delete confirmation', async () => {
-    await expect(
-      helpers.run(theGeneratorPath)
-        .inTmpDir(dir => {
-          writeFakeActionFile(dir, 'fakeName')
-        })
-        .withPrompts({ actionName: 'fakeName', deleteEventAction: true })
-    ).resolves.toEqual(expect.any(String))
-
-    assert.noFile('actions/fakeName/index.js')
-    assert.file('manifest.yml')
-    assert.noFileContent('manifest.yml', 'fakeName')
-    assert.noFileContent('manifest.yml', 'function: actions/fakeName/index.js')
-  })
-
-  test('prompts action name `fakeName` and prompts false to delete confirmation', async () => {
-    await expect(
-      helpers.run(theGeneratorPath)
-        .inTmpDir(dir => {
-          writeFakeActionFile(dir, 'fakeName')
-        })
-        .withPrompts({ actionName: 'fakeName', deleteEventAction: false })
-    ).resolves.toEqual(expect.any(String))
-
-    assert.file('actions/fakeName/index.js')
-    assert.file('manifest.yml')
-    assert.fileContent('manifest.yml', 'fakeName')
-    assert.fileContent('manifest.yml', 'function: actions/fakeName/index.js')
-  })
-
-  test('--action-name=fakeName and prompts yes to delete confirmation', async () => {
-    await expect(
-      helpers.run(theGeneratorPath)
-        .withOptions({ 'action-name': 'fakeName' })
-        .inTmpDir(dir => {
-          writeFakeActionFile(dir, 'fakeName')
-        })
-        .withPrompts({ deleteEventAction: true })
-    ).resolves.toEqual(expect.any(String))
-
-    assert.noFile('actions/fakeName/index.js')
-    assert.file('manifest.yml')
-    assert.noFileContent('manifest.yml', 'fakeName')
-    assert.noFileContent('manifest.yml', 'function: actions/fakeName/index.js')
-  })
-
-  test('--action-name=fakeName and prompts false to delete confirmation', async () => {
-    await expect(
-      helpers.run(theGeneratorPath)
-        .withOptions({ 'action-name': 'fakeName' })
-        .inTmpDir(dir => {
-          writeFakeActionFile(dir, 'fakeName')
-        })
-        .withPrompts({ deleteEventAction: false })
-    ).resolves.toEqual(expect.any(String))
-
-    assert.file('actions/fakeName/index.js')
-    assert.file('manifest.yml')
-    assert.fileContent('manifest.yml', 'fakeName')
-    assert.fileContent('manifest.yml', 'function: actions/fakeName/index.js')
-  })
-
-  test('--skip-prompt --action-name=fakeName', async () => {
-    await expect(
-      helpers.run(theGeneratorPath)
-        .withOptions({ 'skip-prompt': true, 'action-name': 'fakeName' })
-        .inTmpDir(dir => {
-          writeFakeActionFile(dir, 'fakeName')
-        })
-    ).resolves.toEqual(expect.any(String))
-
-    assert.noFile('actions/fakeName/index.js')
-    assert.file('manifest.yml')
-    assert.noFileContent('manifest.yml', 'fakeName')
-    assert.noFileContent('manifest.yml', 'function: actions/fakeName/index.js')
-  })
-
-  test('--skip-prompt --action-name=fakeName AND action.function points to dir in manifest', async () => {
-    await expect(
-      helpers.run(theGeneratorPath)
-        .withOptions({ 'skip-prompt': true, 'action-name': 'fakeName' })
-        .inTmpDir(dir => {
-          writeFakeActionFile(dir, 'fakeName', true)
-        })
-    ).resolves.toEqual(expect.any(String))
-
-    assert.noFile('actions/fakeName/index.js')
-    assert.file('manifest.yml')
-    assert.noFileContent('manifest.yml', 'fakeName')
-    assert.noFileContent('manifest.yml', 'function: actions/fakeName/index.js')
+  test('--skip-prompt and action-name"', async () => {
+    await helpers.run(theGeneratorPath)
+      .withOptions({ 'skip-prompt': true, 'action-name': actionName })
+    // with skip prompt defaults to generic action
+    // make sure sub generators have been called
+    expect(composeWith).toHaveBeenCalledTimes(1)
+    expect(composeWith).toHaveBeenCalledWith(expectedDefaultEventsGenerator, expect.objectContaining({
+      'skip-prompt': true,
+      'action-name': actionName
+    }))
   })
 })


### PR DESCRIPTION
Added generator to delete event similar to delete action
Delete generator will delete selected action source code, e2e test and unit tests associated with it.
Added tests

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

manual and unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
