### PR TITLE
Remove @react-spectrum/typography dependency

### DIFF
--- a/generators/add-web-assets/exc-react/index.js
+++ b/generators/add-web-assets/exc-react/index.js
@@ -59,8 +59,7 @@ class ExcReactGenerator extends Generator {
       '@react-spectrum/provider': '3.0.0-rc.2',
       '@react-spectrum/text': '3.0.0-rc.0',
       '@react-spectrum/textfield': '3.0.0-rc.2',
-      '@react-spectrum/theme-default': '3.0.0-rc.2',
-      '@react-spectrum/typography': '3.0.0-alpha.1'
+      '@react-spectrum/theme-default': '3.0.0-rc.2'
     })
     utils.addDependencies(this, {
       '@babel/core': '^7.8.7',

--- a/test/generators/add-web-assets/exc-react.test.js
+++ b/test/generators/add-web-assets/exc-react.test.js
@@ -60,8 +60,7 @@ function assertDependencies () {
       '@react-spectrum/provider': expect.any(String),
       '@react-spectrum/text': expect.any(String),
       '@react-spectrum/textfield': expect.any(String),
-      '@react-spectrum/theme-default': expect.any(String),
-      '@react-spectrum/typography': expect.any(String)
+      '@react-spectrum/theme-default': expect.any(String)
     },
     devDependencies: {
       '@babel/core': expect.any(String),


### PR DESCRIPTION
`@react-spectrum/typography` is no longer used in code but still listed as a dependency in package.json. It results in 404 error by `npm install` due to missing package `@react-types/typography`, hence needs to be removed.