### PR TITLE
NUI-642 Lower default action concurrency for asset compute to 10

### DIFF
--- a/generators/add-action/asset-compute/index.js
+++ b/generators/add-action/asset-compute/index.js
@@ -51,7 +51,12 @@ class AssetComputeGenerator extends ActionGenerator {
         ]
       },
       actionManifestConfig: {
-        annotations: { 'require-adobe-auth': true }
+        limits: {
+          concurrency: 10
+        },
+        annotations: {
+          'require-adobe-auth': true
+        }
       }
     })
 

--- a/test/generators/add-action/asset-compute.test.js
+++ b/test/generators/add-action/asset-compute.test.js
@@ -62,6 +62,9 @@ function assertManifestContent (actionName) {
     function: `actions${path.sep}${actionName}${path.sep}index.js`,
     web: 'yes',
     runtime: 'nodejs:10',
+    limits: {
+      concurrency: 10
+    },
     annotations: {
       'require-adobe-auth': true
     }


### PR DESCRIPTION
[NUI-642](https://jira.corp.adobe.com/browse/NUI-642).

Asset compute workers are IO intensive. With the default 256 MB memory size the default concurrency of 200 is too high. Setting the default to 10. Our developer documentation will guide developers on finding the right value for their workers.
