### PR TITLE
fix: double import/deconstruct statements sdk libs in actions

### DIFF
--- a/generators/add-action/analytics/index.js
+++ b/generators/add-action/analytics/index.js
@@ -23,7 +23,7 @@ class AnalyticsGenerator extends ActionGenerator {
       // eslint-disable-next-line quotes
       requiredHeaders: `['Authorization']`,
       // eslint-disable-next-line quotes
-      importCode: `const { Analytics } = require('@adobe/aio-sdk')`,
+      importCode: `const { Core, Analytics } = require('@adobe/aio-sdk')`,
       responseCode: `// initialize the sdk
     const analyticsClient = await Analytics.init(params.companyId, params.apiKey, token)
 

--- a/generators/add-action/audience-manager-cd/index.js
+++ b/generators/add-action/audience-manager-cd/index.js
@@ -23,7 +23,7 @@ class AudienceManagerCDGenerator extends ActionGenerator {
       // eslint-disable-next-line quotes
       requiredHeaders: `['Authorization', 'x-gw-ims-org-id']`,
       // eslint-disable-next-line quotes
-      importCode: `const { AudienceManagerCD } = require('@adobe/aio-sdk')`,
+      importCode: `const { Core, AudienceManagerCD } = require('@adobe/aio-sdk')`,
       responseCode: `// initialize the sdk
     const orgId = params.__ow_headers['x-gw-ims-org-id']
     const audienceManagerClient = await AudienceManagerCD.init(orgId, params.apiKey, token)

--- a/generators/add-action/campaign-standard/index.js
+++ b/generators/add-action/campaign-standard/index.js
@@ -23,7 +23,7 @@ class CampaignStandardGenerator extends ActionGenerator {
       // eslint-disable-next-line quotes
       requiredHeaders: `['Authorization']`,
       // eslint-disable-next-line quotes
-      importCode: `const { CampaignStandard } = require('@adobe/aio-sdk')`,
+      importCode: `const { Core, CampaignStandard } = require('@adobe/aio-sdk')`,
       responseCode: `// initialize the sdk
     const campaignClient = await CampaignStandard.init(params.tenant, params.apiKey, token)
 

--- a/generators/add-action/customer-profile/index.js
+++ b/generators/add-action/customer-profile/index.js
@@ -23,7 +23,7 @@ class CustomerProfileGenerator extends ActionGenerator {
       // eslint-disable-next-line quotes
       requiredHeaders: `['Authorization', 'x-gw-ims-org-id']`,
       // eslint-disable-next-line quotes
-      importCode: `const { CustomerProfile } = require('@adobe/aio-sdk')`,
+      importCode: `const { Core, CustomerProfile } = require('@adobe/aio-sdk')`,
       responseCode: `// initialize sdk
     const orgId = params.__ow_headers['x-gw-ims-org-id']
     const client = await CustomerProfile.init(params.tenant, orgId, params.apiKey, token)

--- a/generators/add-action/generic/index.js
+++ b/generators/add-action/generic/index.js
@@ -23,7 +23,9 @@ class GenericGenerator extends ActionGenerator {
       // eslint-disable-next-line quotes
       requiredHeaders: `['Authorization']`,
       // eslint-disable-next-line quotes
-      importCode: `const fetch = require('node-fetch')`,
+      importCode: `const fetch = require('node-fetch')
+const { Core } = require('@adobe/aio-sdk')`,
+
       responseCode: `// replace this with the api you want to access
     const apiEndpoint = 'https://adobeioruntime.net/api/v1/api-docs'
 

--- a/generators/add-action/target/index.js
+++ b/generators/add-action/target/index.js
@@ -24,7 +24,7 @@ class TargetGenerator extends ActionGenerator {
       // eslint-disable-next-line quotes
       requiredHeaders: `['Authorization']`,
       // eslint-disable-next-line quotes
-      importCode: `const {Core, Target } = require('@adobe/aio-sdk')`,
+      importCode: `const { Core, Target } = require('@adobe/aio-sdk')`,
       responseCode: `// initialize the sdk
     const targetClient = await Target.init(params.tenant, params.apiKey, token)
 

--- a/generators/add-action/target/index.js
+++ b/generators/add-action/target/index.js
@@ -24,7 +24,7 @@ class TargetGenerator extends ActionGenerator {
       // eslint-disable-next-line quotes
       requiredHeaders: `['Authorization']`,
       // eslint-disable-next-line quotes
-      importCode: `const { Target } = require('@adobe/aio-sdk')`,
+      importCode: `const {Core, Target } = require('@adobe/aio-sdk')`,
       responseCode: `// initialize the sdk
     const targetClient = await Target.init(params.tenant, params.apiKey, token)
 

--- a/generators/add-events/publish-events/index.js
+++ b/generators/add-events/publish-events/index.js
@@ -22,7 +22,7 @@ class CloudEventsGenerator extends ActionGenerator {
       requiredParams: `['apiKey', 'providerId', 'eventCode', 'payload']`,
       // eslint-disable-next-line quotes
       requiredHeaders: `['Authorization', 'x-gw-ims-org-id']`,
-      importCode: `const { Events } = require('@adobe/aio-sdk')
+      importCode: `const { Core, Events } = require('@adobe/aio-sdk')
 const uuid = require('uuid')
 const cloudEventV1 = require('cloudevents-sdk/v1')`,
       inlineUtilityFunctions: `

--- a/generators/common-templates/stub-action.js
+++ b/generators/common-templates/stub-action.js
@@ -21,7 +21,10 @@ governing permissions and limitations under the License.
  *   - The two steps above imply that every client knowing the URL to this deployed action will be able to invoke it without any authentication and authorization checks against Adobe Identity Management System
  *   - Make sure to validate these changes against your security requirements before deploying the action
  */
+
+<% if (!locals.importCode) { %>
 const { Core } = require('@adobe/aio-sdk')
+<% } %>
 <% if (locals.importCode) { %><%- importCode %><% } %>
 const { errorResponse, getBearerToken, stringParameters, checkMissingRequestInputs } = require('../utils')
 

--- a/test/generators/add-action/analytics.test.js
+++ b/test/generators/add-action/analytics.test.js
@@ -80,6 +80,10 @@ function assertActionCodeContent (actionName) {
   // a few checks to make sure the action calls the analytics sdk
   assert.fileContent(
     theFile,
+    'const { Core, Analytics } = require(\'@adobe/aio-sdk\')'
+  )
+  assert.fileContent(
+    theFile,
     'const requiredParams = [\'apiKey\', \'companyId\']'
   )
   assert.fileContent(

--- a/test/generators/add-action/audience-manager-cd.test.js
+++ b/test/generators/add-action/audience-manager-cd.test.js
@@ -72,6 +72,10 @@ function assertActionCodeContent (actionName) {
   // a few checks to make sure the action calls the audienceManagerCD sdk
   assert.fileContent(
     theFile,
+    'const { Core, AudienceManagerCD } = require(\'@adobe/aio-sdk\')'
+  )
+  assert.fileContent(
+    theFile,
     'const requiredParams = [\'apiKey\', \'id\', \'dataSourceId\']'
   )
   assert.fileContent(

--- a/test/generators/add-action/campaign-standard.test.js
+++ b/test/generators/add-action/campaign-standard.test.js
@@ -80,6 +80,10 @@ function assertActionCodeContent (actionName) {
   // a few checks to make sure the action calls the sdk
   assert.fileContent(
     theFile,
+    'const { Core, CampaignStandard } = require(\'@adobe/aio-sdk\')'
+  )
+  assert.fileContent(
+    theFile,
     'const requiredParams = [\'apiKey\', \'tenant\']'
   )
   assert.fileContent(

--- a/test/generators/add-action/customer-profile.test.js
+++ b/test/generators/add-action/customer-profile.test.js
@@ -80,6 +80,10 @@ function assertActionCodeContent (actionName) {
   // a few checks to make sure the action calls the sdk
   assert.fileContent(
     theFile,
+    'const { Core, CustomerProfile } = require(\'@adobe/aio-sdk\')'
+  )
+  assert.fileContent(
+    theFile,
     'const requiredParams = [\'tenant\', \'apiKey\', \'entityId\', \'entityIdNS\']'
   )
   assert.fileContent(

--- a/test/generators/add-action/generic.test.js
+++ b/test/generators/add-action/generic.test.js
@@ -70,6 +70,10 @@ function assertActionCodeContent (actionName) {
   const theFile = `${constants.actionsDirname}/${actionName}/index.js`
   assert.fileContent(
     theFile,
+    'const { Core } = require(\'@adobe/aio-sdk\')'
+  )
+  assert.fileContent(
+    theFile,
     'const res = await fetch(apiEndpoint)'
   )
   assert.fileContent(

--- a/test/generators/add-action/target.test.js
+++ b/test/generators/add-action/target.test.js
@@ -80,6 +80,10 @@ function assertActionCodeContent (actionName) {
   // a few checks to make sure the action calls the sdk
   assert.fileContent(
     theFile,
+    'const { Core, Target } = require(\'@adobe/aio-sdk\')'
+  )
+  assert.fileContent(
+    theFile,
     'const requiredParams = [\'apiKey\', \'tenant\']'
   )
   assert.fileContent(

--- a/test/generators/add-events/publish-events.test.js
+++ b/test/generators/add-events/publish-events.test.js
@@ -78,6 +78,10 @@ function assertEventCodeContent (actionName) {
   // a few checks to make sure the action calls the events sdk to publish cloud events
   assert.fileContent(
     theFile,
+    'const { Core, Events } = require(\'@adobe/aio-sdk\')'
+  )
+  assert.fileContent(
+    theFile,
     'const requiredParams = [\'apiKey\', \'providerId\', \'eventCode\', \'payload\']'
   )
   assert.fileContent(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix double importing deconstructed libs in action templates

<!--- Describe your changes in detail -->

## Related Issue
Fix: #76 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
sc from issue
<img width="798" alt="Screen Shot 2020-07-06 at 6 33 56 PM" src="https://user-images.githubusercontent.com/46134/86684817-c009a780-bfb7-11ea-8e92-2e348369e1e1.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
