### PR TITLE
Fixed file overwrite confirmation when new action is added 

### DIFF
--- a/lib/ActionGenerator.js
+++ b/lib/ActionGenerator.js
@@ -136,6 +136,23 @@ class ActionGenerator extends Generator {
   }
 
   /** @private */
+  loadManifestFromFS (manifestPath) {
+    if (!fs.existsSync(manifestPath)) {
+      // stub manifest content
+      return {
+        packages: {
+          [manifestPackagePlaceholder]: {
+            license: 'Apache-2.0',
+            actions: {}
+          }
+        }
+      }
+    } else {
+      return yaml.safeLoad(fs.readFileSync(manifestPath))
+    }
+  }
+
+  /** @private */
   writeTplAction (actionName, tplActionPath, tplContext) {
     // always actions/actionName/index.js
     // option for custom action destination path
@@ -150,7 +167,7 @@ class ActionGenerator extends Generator {
   /** @private */
   writeActionManifest (actionName, actionPath, actionManifestConfig = {}) {
     const manifestPath = this.destinationPath('manifest.yml')
-    const manifest = this.loadManifest(manifestPath)
+    const manifest = this.loadManifestFromFS(manifestPath)
 
     manifest.packages[manifestPackagePlaceholder].actions[actionName] = {
       function: path.relative(path.dirname(manifestPath), actionPath),
@@ -159,7 +176,6 @@ class ActionGenerator extends Generator {
       ...actionManifestConfig,
       annotations: { 'require-adobe-auth': true, ...actionManifestConfig.annotations }
     }
-
     // Use fs to write mainfest as this.fs.write asks user for file overwrite
     fs.writeFileSync(manifestPath, yaml.safeDump(manifest))
   }

--- a/lib/ActionGenerator.js
+++ b/lib/ActionGenerator.js
@@ -14,7 +14,7 @@ const yaml = require('js-yaml')
 const path = require('path')
 const upath = require('upath')
 const { EOL } = require('os')
-
+const fs = require('fs-extra')
 const Generator = require('yeoman-generator')
 
 const { manifestPackagePlaceholder, dotenvFilename, actionsDirname } = require('./constants')
@@ -160,7 +160,8 @@ class ActionGenerator extends Generator {
       annotations: { 'require-adobe-auth': true, ...actionManifestConfig.annotations }
     }
 
-    this.fs.write(manifestPath, yaml.safeDump(manifest))
+    // Use fs to write mainfest as this.fs.write asks user for file overwrite
+    fs.writeFileSync(manifestPath, yaml.safeDump(manifest))
   }
 
   /** @private */

--- a/test/lib/ActionGenerator.test.js
+++ b/test/lib/ActionGenerator.test.js
@@ -207,11 +207,13 @@ describe('implementation', () => {
         writeJSON: jest.fn(),
         readJSON: jest.fn().mockReturnValue({}) // package.json read
       }
+
       actionGenerator.addAction('myAction', './templateFile.js')
       // test manifest update with action information
       expect(spyFsWrite).toHaveBeenCalledWith(n('/fakeDestRoot/manifest.yml'), yaml.safeDump({
         packages: {
           [constants.manifestPackagePlaceholder]: {
+            license: 'Apache-2.0',
             actions: {
               myAction: {
                 function: n(`${constants.actionsDirname}/myAction/index.js`), // relative path is important here
@@ -221,8 +223,7 @@ describe('implementation', () => {
                   'require-adobe-auth': true
                 }
               }
-            },
-            fake: 'value'
+            }
           }
         }
       }))


### PR DESCRIPTION
We will merge manifest.yml changes instead of asking user confirmation to overwrite manifest.yml when new actions are added to aio app 

Replaced yeoman Generator.fs.write call with fs.writeFileSync which allows file overwrite
Related to - [https://github.com/adobe/aio-cli-plugin-app/issues/262](https://github.com/adobe/aio-cli-plugin-app/issues/262)

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
