### PR TITLE
Upgrade to Parcel v2 and Node 14 support

### DIFF
--- a/generators/add-vscode-config/VsCodeConfiguration.js
+++ b/generators/add-vscode-config/VsCodeConfiguration.js
@@ -54,14 +54,14 @@ function createLaunchConfiguration (params) {
  * @param {String} params.webDistDev the path to the web dist-dev folder
  */
 function createChromeLaunchConfiguration (params) {
-  const { url, webRoot, webDistDev } = params
+  const { url, webRoot } = params
   return {
     ...createLaunchConfiguration({ type: 'chrome', name: 'Web', request: 'launch' }),
     url,
     webRoot,
     breakOnLoad: true,
     sourceMapPathOverrides: {
-      '*': path.join(webDistDev, '*')
+      '/__parcel_source_root/*': '${workspaceFolder}/*' // eslint-disable-line no-template-curly-in-string
     }
   }
 }

--- a/generators/add-web-assets/exc-react/index.js
+++ b/generators/add-web-assets/exc-react/index.js
@@ -49,7 +49,8 @@ class ExcReactGenerator extends Generator {
     )
     // add .babelrc
     this.fs.writeJSON(this.destinationPath('.babelrc'), {
-      presets: [['@babel/preset-env', { targets: { node: 'current' } }]]
+      presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
+      plugins: ['@babel/plugin-transform-react-jsx']
     })
     // add dependencies
     utils.addDependencies(this, {
@@ -68,7 +69,8 @@ class ExcReactGenerator extends Generator {
       {
         '@babel/core': '^7.8.7',
         '@babel/polyfill': '^7.8.7',
-        '@babel/preset-env': '^7.8.7'
+        '@babel/preset-env': '^7.8.7',
+        '@babel/plugin-transform-react-jsx': '^7.8.3'
       },
       true
     )

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
   },
   "devDependencies": {
-      "jest": "^24.9.0"
+      "jest": "^26.6.3"
   },
   "scripts": {
       "test": "jest --passWithNoTests ./test",

--- a/lib/ActionGenerator.js
+++ b/lib/ActionGenerator.js
@@ -198,7 +198,7 @@ class ActionGenerator extends Generator {
     const engines = content.engines || {}
     if (!engines.node) {
       // do not overwrite existing node engines
-      engines.node = '^12 || ^14'
+      engines.node = '^10 || ^12 || ^14'
       utils.writePackageJson(this, { ...content, engines })
     }
   }

--- a/lib/ActionGenerator.js
+++ b/lib/ActionGenerator.js
@@ -155,7 +155,7 @@ class ActionGenerator extends Generator {
     manifest.packages[manifestPackagePlaceholder].actions[actionName] = {
       function: path.relative(path.dirname(manifestPath), actionPath),
       web: 'yes',
-      runtime: 'nodejs:12',
+      runtime: 'nodejs:14',
       ...actionManifestConfig,
       annotations: { 'require-adobe-auth': true, ...actionManifestConfig.annotations }
     }

--- a/lib/ActionGenerator.js
+++ b/lib/ActionGenerator.js
@@ -198,7 +198,7 @@ class ActionGenerator extends Generator {
     const engines = content.engines || {}
     if (!engines.node) {
       // do not overwrite existing node engines
-      engines.node = '^10 || ^12'
+      engines.node = '^12 || ^14'
       utils.writePackageJson(this, { ...content, engines })
     }
   }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
-    "jest": "^24.9.0",
+    "jest": "^26.6.3",
     "stdout-stderr": "^0.1.13",
     "yeoman-assert": "^3.1.1",
     "yeoman-test": "^2.6.0"

--- a/test/generators/add-action/analytics.test.js
+++ b/test/generators/add-action/analytics.test.js
@@ -57,7 +57,7 @@ function assertManifestContent (actionName) {
   expect(json.packages[constants.manifestPackagePlaceholder].actions[actionName]).toEqual({
     function: path.normalize(`${constants.actionsDirname}/${actionName}/index.js`),
     web: 'yes',
-    runtime: 'nodejs:12',
+    runtime: 'nodejs:14',
     inputs: {
       LOG_LEVEL: 'debug',
       apiKey: '$SERVICE_API_KEY',

--- a/test/generators/add-action/analytics.test.js
+++ b/test/generators/add-action/analytics.test.js
@@ -117,7 +117,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('--skip-prompt, and action with default name already exists', async () => {
@@ -145,7 +145,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('user input actionName=fakeAction', async () => {
@@ -164,6 +164,6 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 })

--- a/test/generators/add-action/analytics.test.js
+++ b/test/generators/add-action/analytics.test.js
@@ -117,7 +117,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('--skip-prompt, and action with default name already exists', async () => {
@@ -145,7 +145,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('user input actionName=fakeAction', async () => {
@@ -164,6 +164,6 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 })

--- a/test/generators/add-action/asset-compute.test.js
+++ b/test/generators/add-action/asset-compute.test.js
@@ -120,7 +120,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/asset-compute-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String), '@adobe/aio-cli-plugin-asset-compute': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('asset-compute: --skip-prompt, and action with default name already exists', async () => {
@@ -147,7 +147,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/asset-compute-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String), '@adobe/aio-cli-plugin-asset-compute': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('asset-compute: --skip-prompt, and action already has package.json with scripts', async () => {
@@ -168,7 +168,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/asset-compute-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String), '@adobe/aio-cli-plugin-asset-compute': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('asset-compute: user input actionName=new-action', async () => {
@@ -187,7 +187,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/asset-compute-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String), '@adobe/aio-cli-plugin-asset-compute': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('asset-compute: adding an action 2 times', async () => {

--- a/test/generators/add-action/asset-compute.test.js
+++ b/test/generators/add-action/asset-compute.test.js
@@ -120,7 +120,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/asset-compute-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String), '@adobe/aio-cli-plugin-asset-compute': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('asset-compute: --skip-prompt, and action with default name already exists', async () => {
@@ -147,7 +147,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/asset-compute-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String), '@adobe/aio-cli-plugin-asset-compute': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('asset-compute: --skip-prompt, and action already has package.json with scripts', async () => {
@@ -168,7 +168,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/asset-compute-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String), '@adobe/aio-cli-plugin-asset-compute': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('asset-compute: user input actionName=new-action', async () => {
@@ -187,7 +187,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/asset-compute-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String), '@adobe/aio-cli-plugin-asset-compute': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('asset-compute: adding an action 2 times', async () => {

--- a/test/generators/add-action/asset-compute.test.js
+++ b/test/generators/add-action/asset-compute.test.js
@@ -61,7 +61,7 @@ function assertManifestContent (actionName) {
   expect(json.packages[constants.manifestPackagePlaceholder].actions[actionName]).toEqual({
     function: `actions${path.sep}${actionName}${path.sep}index.js`,
     web: 'yes',
-    runtime: 'nodejs:12',
+    runtime: 'nodejs:14',
     limits: {
       concurrency: 10
     },

--- a/test/generators/add-action/audience-manager-cd.test.js
+++ b/test/generators/add-action/audience-manager-cd.test.js
@@ -103,7 +103,7 @@ describe('run', () => {
     assertActionCodeContent(actionName)
     assertManifestContent(actionName)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('--skip-prompt, and action with default name already exists', async () => {
@@ -128,7 +128,7 @@ describe('run', () => {
     assertActionCodeContent(actionName)
     assertManifestContent(actionName)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('user input actionName=fakeAction', async () => {
@@ -142,6 +142,6 @@ describe('run', () => {
     assertActionCodeContent(actionName)
     assertManifestContent(actionName)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 })

--- a/test/generators/add-action/audience-manager-cd.test.js
+++ b/test/generators/add-action/audience-manager-cd.test.js
@@ -103,7 +103,7 @@ describe('run', () => {
     assertActionCodeContent(actionName)
     assertManifestContent(actionName)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('--skip-prompt, and action with default name already exists', async () => {
@@ -128,7 +128,7 @@ describe('run', () => {
     assertActionCodeContent(actionName)
     assertManifestContent(actionName)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('user input actionName=fakeAction', async () => {
@@ -142,6 +142,6 @@ describe('run', () => {
     assertActionCodeContent(actionName)
     assertManifestContent(actionName)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 })

--- a/test/generators/add-action/audience-manager-cd.test.js
+++ b/test/generators/add-action/audience-manager-cd.test.js
@@ -55,7 +55,7 @@ function assertManifestContent (actionName) {
   expect(json.packages[constants.manifestPackagePlaceholder].actions[actionName]).toEqual({
     function: path.normalize(`${constants.actionsDirname}/${actionName}/index.js`),
     web: 'yes',
-    runtime: 'nodejs:12',
+    runtime: 'nodejs:14',
     inputs: {
       LOG_LEVEL: 'debug',
       apiKey: '$SERVICE_API_KEY'

--- a/test/generators/add-action/campaign-standard.test.js
+++ b/test/generators/add-action/campaign-standard.test.js
@@ -57,7 +57,7 @@ function assertManifestContent (actionName) {
   expect(json.packages[constants.manifestPackagePlaceholder].actions[actionName]).toEqual({
     function: path.normalize(`${constants.actionsDirname}/${actionName}/index.js`),
     web: 'yes',
-    runtime: 'nodejs:12',
+    runtime: 'nodejs:14',
     inputs: {
       LOG_LEVEL: 'debug',
       apiKey: '$SERVICE_API_KEY',

--- a/test/generators/add-action/campaign-standard.test.js
+++ b/test/generators/add-action/campaign-standard.test.js
@@ -117,7 +117,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('--skip-prompt, and action with default name already exists', async () => {
@@ -145,7 +145,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('user input actionName=fakeAction', async () => {
@@ -164,6 +164,6 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 })

--- a/test/generators/add-action/campaign-standard.test.js
+++ b/test/generators/add-action/campaign-standard.test.js
@@ -117,7 +117,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('--skip-prompt, and action with default name already exists', async () => {
@@ -145,7 +145,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('user input actionName=fakeAction', async () => {
@@ -164,6 +164,6 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 })

--- a/test/generators/add-action/customer-profile.test.js
+++ b/test/generators/add-action/customer-profile.test.js
@@ -57,7 +57,7 @@ function assertManifestContent (actionName) {
   expect(json.packages[constants.manifestPackagePlaceholder].actions[actionName]).toEqual({
     function: path.normalize(`${constants.actionsDirname}/${actionName}/index.js`),
     web: 'yes',
-    runtime: 'nodejs:12',
+    runtime: 'nodejs:14',
     inputs: {
       LOG_LEVEL: 'debug',
       tenant: '$CUSTOMER_PROFILE_TENANT',

--- a/test/generators/add-action/customer-profile.test.js
+++ b/test/generators/add-action/customer-profile.test.js
@@ -124,7 +124,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('--skip-prompt, and action with default name already exists', async () => {
@@ -152,7 +152,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('user input actionName=fakeAction', async () => {
@@ -171,6 +171,6 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 })

--- a/test/generators/add-action/customer-profile.test.js
+++ b/test/generators/add-action/customer-profile.test.js
@@ -124,7 +124,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('--skip-prompt, and action with default name already exists', async () => {
@@ -152,7 +152,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('user input actionName=fakeAction', async () => {
@@ -171,6 +171,6 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 })

--- a/test/generators/add-action/generic.test.js
+++ b/test/generators/add-action/generic.test.js
@@ -94,7 +94,7 @@ describe('run', () => {
     assertActionCodeContent(actionName)
     assertManifestContent(actionName)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String), 'node-fetch': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('--skip-prompt, and action with default name already exists', async () => {
@@ -119,7 +119,7 @@ describe('run', () => {
     assertActionCodeContent(actionName)
     assertManifestContent(actionName)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String), 'node-fetch': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('user input actionName=fakeAction', async () => {
@@ -133,6 +133,6 @@ describe('run', () => {
     assertActionCodeContent(actionName)
     assertManifestContent(actionName)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String), 'node-fetch': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 })

--- a/test/generators/add-action/generic.test.js
+++ b/test/generators/add-action/generic.test.js
@@ -55,7 +55,7 @@ function assertManifestContent (actionName) {
   expect(json.packages[constants.manifestPackagePlaceholder].actions[actionName]).toEqual({
     function: path.normalize(`${constants.actionsDirname}/${actionName}/index.js`),
     web: 'yes',
-    runtime: 'nodejs:12',
+    runtime: 'nodejs:14',
     inputs: {
       LOG_LEVEL: 'debug'
     },

--- a/test/generators/add-action/generic.test.js
+++ b/test/generators/add-action/generic.test.js
@@ -94,7 +94,7 @@ describe('run', () => {
     assertActionCodeContent(actionName)
     assertManifestContent(actionName)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String), 'node-fetch': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('--skip-prompt, and action with default name already exists', async () => {
@@ -119,7 +119,7 @@ describe('run', () => {
     assertActionCodeContent(actionName)
     assertManifestContent(actionName)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String), 'node-fetch': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('user input actionName=fakeAction', async () => {
@@ -133,6 +133,6 @@ describe('run', () => {
     assertActionCodeContent(actionName)
     assertManifestContent(actionName)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String), 'node-fetch': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 })

--- a/test/generators/add-action/target.test.js
+++ b/test/generators/add-action/target.test.js
@@ -57,7 +57,7 @@ function assertManifestContent (actionName) {
   expect(json.packages[constants.manifestPackagePlaceholder].actions[actionName]).toEqual({
     function: path.normalize(`${constants.actionsDirname}/${actionName}/index.js`),
     web: 'yes',
-    runtime: 'nodejs:12',
+    runtime: 'nodejs:14',
     inputs: {
       LOG_LEVEL: 'debug',
       apiKey: '$SERVICE_API_KEY',

--- a/test/generators/add-action/target.test.js
+++ b/test/generators/add-action/target.test.js
@@ -117,7 +117,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('--skip-prompt, and action with default name already exists', async () => {
@@ -145,7 +145,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('user input actionName=fakeAction', async () => {
@@ -164,6 +164,6 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 })

--- a/test/generators/add-action/target.test.js
+++ b/test/generators/add-action/target.test.js
@@ -117,7 +117,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('--skip-prompt, and action with default name already exists', async () => {
@@ -145,7 +145,7 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('user input actionName=fakeAction', async () => {
@@ -164,6 +164,6 @@ describe('run', () => {
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
     assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 })

--- a/test/generators/add-events/publish-events.test.js
+++ b/test/generators/add-events/publish-events.test.js
@@ -119,7 +119,7 @@ describe('run', () => {
       'cloudevents-sdk': expect.any(String),
       uuid: expect.any(String)
     }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('--skip-prompt, and action with default name already exists', async () => {
@@ -151,7 +151,7 @@ describe('run', () => {
       'cloudevents-sdk': expect.any(String),
       uuid: expect.any(String)
     }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 
   test('user input actionName=fakeAction', async () => {
@@ -174,6 +174,6 @@ describe('run', () => {
       'cloudevents-sdk': expect.any(String),
       uuid: expect.any(String)
     }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^10 || ^12')
+    assertNodeEngines(fs, '^12 || ^14')
   })
 })

--- a/test/generators/add-events/publish-events.test.js
+++ b/test/generators/add-events/publish-events.test.js
@@ -57,7 +57,7 @@ function assertManifestContent (actionName) {
   expect(json.packages[constants.manifestPackagePlaceholder].actions[actionName]).toEqual({
     function: path.normalize(`${constants.actionsDirname}/${actionName}/index.js`),
     web: 'yes',
-    runtime: 'nodejs:12',
+    runtime: 'nodejs:14',
     inputs: {
       LOG_LEVEL: 'debug',
       apiKey: '$SERVICE_API_KEY'

--- a/test/generators/add-events/publish-events.test.js
+++ b/test/generators/add-events/publish-events.test.js
@@ -119,7 +119,7 @@ describe('run', () => {
       cloudevents: expect.any(String),
       uuid: expect.any(String)
     }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('--skip-prompt, and action with default name already exists', async () => {
@@ -151,7 +151,7 @@ describe('run', () => {
       cloudevents: expect.any(String),
       uuid: expect.any(String)
     }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
   test('user input actionName=fakeAction', async () => {
@@ -174,6 +174,6 @@ describe('run', () => {
       cloudevents: expect.any(String),
       uuid: expect.any(String)
     }, { '@openwhisk/wskdebug': expect.any(String) })
-    assertNodeEngines(fs, '^12 || ^14')
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 })

--- a/test/generators/add-vscode-config/VsCodeConfiguration.test.js
+++ b/test/generators/add-vscode-config/VsCodeConfiguration.test.js
@@ -62,7 +62,7 @@ test('createChromeLaunchConfiguration', () => {
     webRoot: params.webRoot,
     breakOnLoad: true,
     sourceMapPathOverrides: {
-      '*': path.join(params.webDistDev, '*')
+      '/__parcel_source_root/*': '${workspaceFolder}/*' // eslint-disable-line no-template-curly-in-string
     }
   })
 })

--- a/test/generators/add-vscode-config/index.test.js
+++ b/test/generators/add-vscode-config/index.test.js
@@ -96,7 +96,7 @@ const createTestLaunchConfiguration = (
         webRoot: 'html',
         breakOnLoad: true,
         sourceMapPathOverrides: {
-          '*': path.join('dist-dev', '*')
+          '/__parcel_source_root/*': '${workspaceFolder}/*' // eslint-disable-line no-template-curly-in-string
         }
       }
     ],

--- a/test/generators/add-web-assets/exc-react.test.js
+++ b/test/generators/add-web-assets/exc-react.test.js
@@ -109,7 +109,8 @@ describe('run', () => {
       {
         '@babel/core': expect.any(String),
         '@babel/polyfill': expect.any(String),
-        '@babel/preset-env': expect.any(String)
+        '@babel/preset-env': expect.any(String),
+        '@babel/plugin-transform-react-jsx': expect.any(String)
       }
     )
     assertEnvContent(prevDotEnv)
@@ -155,7 +156,8 @@ describe('run', () => {
       {
         '@babel/core': expect.any(String),
         '@babel/polyfill': expect.any(String),
-        '@babel/preset-env': expect.any(String)
+        '@babel/preset-env': expect.any(String),
+        '@babel/plugin-transform-react-jsx': expect.any(String)
       }
     )
     assertEnvContent(prevDotEnv)

--- a/test/lib/ActionGenerator.test.js
+++ b/test/lib/ActionGenerator.test.js
@@ -441,7 +441,7 @@ describe('implementation', () => {
       actionGenerator.addAction('myAction', './templateFile.js')
 
       expect(actionGenerator.fs.writeJSON).not.toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
-        engines: { node: '^10 || ^12' }
+        engines: { node: '^12 || ^14' }
       }))
       // as part of addDependency call
       expect(actionGenerator.fs.writeJSON).toHaveBeenCalledWith(n('/fakeDestRoot/package.json'), expect.objectContaining({
@@ -460,7 +460,7 @@ describe('implementation', () => {
       actionGenerator.addAction('myAction', './templateFile.js')
 
       expect(actionGenerator.fs.writeJSON).toHaveBeenCalledWith(n('/fakeDestRoot/package.json'), expect.objectContaining({
-        engines: { notnode: '1 || 2', node: '^10 || ^12' }
+        engines: { notnode: '1 || 2', node: '^12 || ^14' }
       }))
     })
     test('with non existing package.json engines', () => {
@@ -475,7 +475,7 @@ describe('implementation', () => {
       actionGenerator.addAction('myAction', './templateFile.js')
 
       expect(actionGenerator.fs.writeJSON).toHaveBeenCalledWith(n('/fakeDestRoot/package.json'), expect.objectContaining({
-        engines: { node: '^10 || ^12' }
+        engines: { node: '^12 || ^14' }
       }))
     })
   })

--- a/test/lib/ActionGenerator.test.js
+++ b/test/lib/ActionGenerator.test.js
@@ -121,7 +121,7 @@ describe('implementation', () => {
               fakedefault: {
                 function: '/myAction/index.js',
                 web: 'yes',
-                runtime: 'nodejs:12'
+                runtime: 'nodejs:14'
               }
             }
           }
@@ -170,7 +170,7 @@ describe('implementation', () => {
               myAction: {
                 function: n(`${constants.actionsDirname}/myAction/index.js`), // relative path is important here
                 web: 'yes',
-                runtime: 'nodejs:12',
+                runtime: 'nodejs:14',
                 annotations: {
                   'require-adobe-auth': true
                 }
@@ -212,7 +212,7 @@ describe('implementation', () => {
               myAction: {
                 function: n(`${constants.actionsDirname}/myAction/index.js`), // relative path is important here
                 web: 'yes',
-                runtime: 'nodejs:12',
+                runtime: 'nodejs:14',
                 annotations: {
                   'require-adobe-auth': true
                 }

--- a/test/lib/ActionGenerator.test.js
+++ b/test/lib/ActionGenerator.test.js
@@ -441,7 +441,7 @@ describe('implementation', () => {
       actionGenerator.addAction('myAction', './templateFile.js')
 
       expect(actionGenerator.fs.writeJSON).not.toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
-        engines: { node: '^12 || ^14' }
+        engines: { node: '^10 || ^12 || ^14' }
       }))
       // as part of addDependency call
       expect(actionGenerator.fs.writeJSON).toHaveBeenCalledWith(n('/fakeDestRoot/package.json'), expect.objectContaining({
@@ -460,7 +460,7 @@ describe('implementation', () => {
       actionGenerator.addAction('myAction', './templateFile.js')
 
       expect(actionGenerator.fs.writeJSON).toHaveBeenCalledWith(n('/fakeDestRoot/package.json'), expect.objectContaining({
-        engines: { notnode: '1 || 2', node: '^12 || ^14' }
+        engines: { notnode: '1 || 2', node: '^10 || ^12 || ^14' }
       }))
     })
     test('with non existing package.json engines', () => {
@@ -475,7 +475,7 @@ describe('implementation', () => {
       actionGenerator.addAction('myAction', './templateFile.js')
 
       expect(actionGenerator.fs.writeJSON).toHaveBeenCalledWith(n('/fakeDestRoot/package.json'), expect.objectContaining({
-        engines: { node: '^12 || ^14' }
+        engines: { node: '^10 || ^12 || ^14' }
       }))
     })
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Building the exc react UI with parcel V2 throws an error `SyntaxError: Support for the experimental syntax 'jsx' isn't currently enabled`. Added it to `plugins` in `.babelrc` and in `devDependencies`.
- Changed default to nodejs:14 because runtime is planning to do the same.


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
