### PR TITLE
fix: shared lib relative path in shared lib test file

### DIFF
--- a/generators/common-templates/utils.test.js
+++ b/generators/common-templates/utils.test.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 * <license header>
 */
 
-const utils = require('../../actions/utils')
+const utils = require('./<%= utilsRelPath %>')
 
 test('interface', () => {
   expect(typeof utils.errorResponse).toBe('function')

--- a/lib/ActionGenerator.js
+++ b/lib/ActionGenerator.js
@@ -102,10 +102,14 @@ class ActionGenerator extends Generator {
       this.writeActionTest(options.testFile, testDestPath, this.actionPath, options.tplContext)
     }
     if (options.sharedLibFile) {
-      this.fs.copyTpl(this.templatePath(options.sharedLibFile), this.destinationPath(path.join(this.actionFolder, path.basename(options.sharedLibFile))), options.tplContext)
-    }
-    if (options.sharedLibFile && options.sharedLibTestFile) {
-      this.fs.copyTpl(this.templatePath(options.sharedLibTestFile), this.destinationPath('test', this.actionFolder, path.basename(options.sharedLibTestFile)), options.tplContext)
+      // the sharedLibFile is always put in the root of this.actionFolder, this is important for sharedLibTestFile below
+      const sharedLibFileDestPath = this.destinationPath(path.join(this.actionFolder, path.basename(options.sharedLibFile)))
+      this.fs.copyTpl(this.templatePath(options.sharedLibFile), sharedLibFileDestPath, options.tplContext)
+
+      if (options.sharedLibTestFile) {
+        const sharedLibTestFileDestPath = this.destinationPath('test', this.actionFolder, path.basename(options.sharedLibTestFile))
+        this.writeUtilsTest(options.sharedLibTestFile, sharedLibTestFileDestPath, sharedLibFileDestPath, options.tplContext)
+      }
     }
     if (options.e2eTestFile) {
       // this only works if action folder is relative
@@ -191,6 +195,16 @@ class ActionGenerator extends Generator {
     tplContext = { actionRelPath: upath.toUnix(path.relative(path.dirname(testDestPath), actionPath)), ...tplContext }
     // should we support other options of copyTpl (templateOptions && copyOptions) ?
     this.fs.copyTpl(this.templatePath(tplActionTest), testDestPath, tplContext, {}, {})
+
+    return testDestPath
+  }
+
+  /** @private */
+  writeUtilsTest (tplUtilsTest, testDestPath, utilsPath, tplContext) {
+    // enriches tplContext with utilsRelPath to be required from test file
+    tplContext = { utilsRelPath: upath.toUnix(path.relative(path.dirname(testDestPath), utilsPath)), ...tplContext }
+    // should we support other options of copyTpl (templateOptions && copyOptions) ?
+    this.fs.copyTpl(this.templatePath(tplUtilsTest), testDestPath, tplContext, {}, {})
 
     return testDestPath
   }


### PR DESCRIPTION
This PR is for the ext-reg-integration branch
Tested with all the ext-reg libraries npm linked - created a project with an extension, and ran `aio app test`

## Description

This fixes the shared-lib test file's reference to the shared-lib, which was fixed before, now it is dynamic.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
