### PR TITLE
fix: runtime package for e2e tests generator (Ext Reg)

### DIFF
--- a/generators/common-templates/stub-action.e2e.js
+++ b/generators/common-templates/stub-action.e2e.js
@@ -19,7 +19,7 @@ const fetch = require('node-fetch')
 const namespace = Config.get('runtime.namespace')
 const hostname = Config.get('cna.hostname') || 'adobeioruntime.net'
 const packagejson = JSON.parse(fs.readFileSync('package.json').toString())
-const runtimePackage = `${packagejson.name}-${packagejson.version}`
+const runtimePackage = '<%= runtimePackageName %>'
 const actionUrl = `https://${namespace}.${hostname}/api/v1/web/${runtimePackage}/<%= actionName %>`
 
 // The deployed actions are secured with the `require-adobe-auth` annotation.

--- a/lib/ActionGenerator.js
+++ b/lib/ActionGenerator.js
@@ -115,7 +115,7 @@ class ActionGenerator extends Generator {
     if (options.e2eTestFile) {
       // this only works if action folder is relative
       const testDestPath = this.destinationPath(this.extRoot, 'e2e', `${actionName}.e2e.test.js`)
-      this.writeActionE2ETest(options.e2eTestFile, testDestPath, options.tplContext)
+      this.writeActionE2ETest(options.e2eTestFile, testDestPath, { runtimePackageName, ...options.tplContext })
     }
     if (options.dotenvStub) {
       utils.appendStubVarsToDotenv(this, options.dotenvStub.label, options.dotenvStub.vars)


### PR DESCRIPTION
base branch is `release-ext-reg`.

## How Has This Been Tested?

`npm link` this into `aio-cli-plugin-app`
`aio-next plugins link` the app plugin
`aio-next app init foo` then examine the e2e folder for the e2e test, then
`aio-next app action add -e exc` to add more actions, then examine the e2e folder for the e2e tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
