### PR TITLE
git-ignore .aio file

### DIFF
--- a/generators/base-app/templates/_dot.gitignore
+++ b/generators/base-app/templates/_dot.gitignore
@@ -11,6 +11,7 @@ dist
 # Config
 config.json
 .env*
+.aio
 
 # Adobe I/O console config
 console.json


### PR DESCRIPTION
Before, .aio was useful to store and share custom app configs such as actions directory.
Those configs are now in `app.config.yaml` and `ext.config.yaml`.
That leaves .aio containing only project info from console. It is auto-generated and should not be committed to Git.
So .aio should be git-ignored.