### PR TITLE
fix: test folder structure for asset-compute generator

### DIFF
--- a/generators/add-action/asset-compute/index.js
+++ b/generators/add-action/asset-compute/index.js
@@ -50,7 +50,7 @@ class AssetComputeGenerator extends ActionGenerator {
     const extFolder = path.dirname(this.configPath)
 
     // TODO add support in ActionGenerator for copying test folders instead of files
-    const destTestFolder = this.destinationPath(extFolder, 'test')
+    const destTestFolder = this.destinationPath(extFolder, 'test', 'asset-compute', this.props.actionName)
     const workerTemplateTestFiles = `${this.templatePath()}/test/` // copy the rest of the worker template files
     this.fs.copyTpl(
       workerTemplateTestFiles,

--- a/test/generators/add-action/asset-compute.test.js
+++ b/test/generators/add-action/asset-compute.test.js
@@ -41,7 +41,7 @@ describe('prototype', () => {
 
 function assertGeneratedFiles (actionName) {
   const actionPath = `actions/${actionName}`
-  const testPath = 'test'
+  const testPath = `test/asset-compute/${actionName}`
 
   assert.file(`${actionPath}/index.js`)
 


### PR DESCRIPTION
Fixes #157 

<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context

Minimal changes to the expected structure for asset-compute tests.

The asset-compute tests expect a certain location for the tests relative to the root:
```
|____test
| |____asset-compute
| | |____worker
| | | |____simple-test
| | | | |____file.jpg
| | | | |____rendition.jpg
| | | | |____params.json
| | | |____corrupt-input
| | | | |____file.jpg
| | | | |____params.json
|____actions
| |____worker
| | |____index.js
|____ext.config.yaml
```
(here `worker` is the name of the action)

⚠️ However, now the root is not the root of the app, but the root of the extension.

## How Has This Been Tested?

1. aio-cli@8 
2. `aio app init` (get the asset compute extension)
3. Modified https://github.com/adobe/aio-cli-plugin-asset-compute/blob/a13a83ab5a6ea28b35e4fa80a05c3a0beaca9735/src/commands/asset-compute/test-worker.js#L23 with `const TEST_DIR = path.join("src", "dx-asset-compute-worker-1", "test", "asset-compute");`
4. aio app test

The tests run, but there are errors in the `asset-compute` plugin  (which are outside the scope of the generator) due to the new extension registry changes.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
