### PR TITLE
[ACNA-1108] Non windows user can't build an app bootstrapped by a windows user

### DIFF
--- a/generators/extensions/dx-asset-compute-worker-1/index.js
+++ b/generators/extensions/dx-asset-compute-worker-1/index.js
@@ -60,7 +60,7 @@ class DxAssetComputeWorker1 extends Generator {
       'extensions.' + this.configName,
       // value
       {
-        $include: this.extConfigPath
+        $include: this.extConfigPath.split(path.sep).join(path.posix.sep)
       }
     )
 

--- a/generators/extensions/dx-asset-compute-worker-1/index.js
+++ b/generators/extensions/dx-asset-compute-worker-1/index.js
@@ -14,6 +14,7 @@ const Generator = require('yeoman-generator')
 
 const utils = require('../../../lib/utils')
 const { runtimeManifestKey } = require('../../../lib/constants')
+const upath = require('upath')
 
 const assetComputeActionGenerator = path.join(__dirname, '../../add-action/asset-compute/index.js')
 
@@ -53,6 +54,7 @@ class DxAssetComputeWorker1 extends Generator {
   }
 
   async writing () {
+    const unixExtConfigPath = upath.toUnix(this.extConfigPath)
     // add the extension point config in root
     utils.writeKeyAppConfig(
       this,
@@ -60,7 +62,7 @@ class DxAssetComputeWorker1 extends Generator {
       'extensions.' + this.configName,
       // value
       {
-        $include: this.extConfigPath.split(path.sep).join(path.posix.sep)
+        $include: unixExtConfigPath
       }
     )
 

--- a/generators/extensions/dx-excshell-1/index.js
+++ b/generators/extensions/dx-excshell-1/index.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 const path = require('path')
 const Generator = require('yeoman-generator')
 const { runtimeManifestKey } = require('../../../lib/constants')
+const upath = require('upath')
 
 const utils = require('../../../lib/utils')
 
@@ -64,6 +65,7 @@ class DxExcshell1 extends Generator {
   }
 
   async writing () {
+    const unixExtConfigPath = upath.toUnix(this.extConfigPath)
     // add the extension point config in root
     utils.writeKeyAppConfig(
       this,
@@ -72,7 +74,8 @@ class DxExcshell1 extends Generator {
       // value
       {
         // posix separator
-        $include: this.extConfigPath.split(path.sep).join(path.posix.sep)
+
+        $include: unixExtConfigPath
       }
     )
 

--- a/generators/extensions/dx-excshell-1/index.js
+++ b/generators/extensions/dx-excshell-1/index.js
@@ -71,7 +71,8 @@ class DxExcshell1 extends Generator {
       'extensions.' + this.configName,
       // value
       {
-        $include: this.extConfigPath
+        // posix separator
+        $include: this.extConfigPath.split(path.sep).join(path.posix.sep)
       }
     )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The `manifest.yml` file bootstrapped by a windows user will contain `\` to define extension paths. A non windows user can't build the app as an error is thrown due to that.

## Description

<!--- Describe your changes in detail -->
Replaced windows separator with UNIX separator for required paths.

## Related Issue
https://github.com/adobe/aio-cli-plugin-app/issues/384

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
