### PR TITLE
fix: filter out the deprecated url key from config.json

### DIFF
--- a/generators/add-web-assets/exc-react/templates/src/components/ActionsForm.js
+++ b/generators/add-web-assets/exc-react/templates/src/components/ActionsForm.js
@@ -30,8 +30,16 @@ import {
 } from '@adobe/react-spectrum'
 import Function from '@spectrum-icons/workflow/Function'
 
-import actions from '../config.json'
+import allActions from '../config.json'
 import actionWebInvoke from '../utils'
+
+// remove the deprecated key
+const actions = Object.keys(allActions).reduce((obj, key) => {
+  if (key.lastIndexOf("/") > -1) {
+    obj[key] = allActions[key];
+  }
+  return obj;
+}, {});
 
 const ActionsForm = (props) => {
   const [state, setState] = useState({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Due to https://github.com/adobe/aio-lib-runtime/pull/76 changes, the output of config will now include both `pkgName/actionName` and `actionName` as keys.
Filter out the deprecated `actionName` key from generated ActionForm.

<!--- Describe your changes in detail -->

## Depends on
Extends: https://github.com/adobe/aio-lib-runtime/pull/76

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
The ActionForm should not display the duplicate entry of UR with the deprecated key. 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
