### PR TITLE
generate .env  using `aio app use`

### DIFF
--- a/generators/base-app/templates/README.md
+++ b/generators/base-app/templates/README.md
@@ -28,8 +28,10 @@ local serverless stack and also run your actions locally use the `aio app run --
 
 ### `.env`
 
+You can generate this file using the command `aio app use`. 
+
 ```bash
-# This file must not be committed to source control
+# This file must **not** be committed to source control
 
 ## please provide your Adobe I/O Runtime credentials
 # AIO_RUNTIME_AUTH=


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When cloning an existing app-builder project, it not clear how to connect the app to Adobe-IO.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Feedback from own experience. 

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
