### PR TITLE
Fix small error with example command for e2e tests

### DIFF
--- a/generators/base-app/templates/README.md
+++ b/generators/base-app/templates/README.md
@@ -17,7 +17,7 @@ local serverless stack and also run your actions locally use the `aio app run --
 ## Test & Coverage
 
 - Run `aio app test` to run unit tests for ui and actions
-- Run `aio app test -e` to run e2e tests
+- Run `aio app test --e2e` to run e2e tests
 
 ## Deploy & Cleanup
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`aio app test -e` tries to run tests on an extension only, so the example gives the error: 
```
Error: Flag --extension expects a value
```
`aio app test --e2e` will run the end-to-end tests as expected

## Related Issue

Closes #182

## Motivation and Context
Fixes a minor issue with the generated README file that might slow down or frustrate new users of the platform.

## How Has This Been Tested?
Tested updated command locally with the updated command, with reference to the command help.  

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
