### PR TITLE
[READY]#186 add initial action generator for AEMHeadlessClient SDK

### DIFF
--- a/generators/add-action/aem-headless-client/index.js
+++ b/generators/add-action/aem-headless-client/index.js
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const path = require('path')
+const ActionGenerator = require('../../../lib/ActionGenerator')
+
+class AemHeadlessClientGenerator extends ActionGenerator {
+  constructor (args, opts) {
+    super(args, opts)
+    this.props = {
+      description: 'This is a sample action showcasing how to use AEM GraphQL capabilities',
+      // eslint-disable-next-line quotes
+      requiredParams: `[]`,
+      // eslint-disable-next-line quotes
+      requiredHeaders: `['Authorization', 'x-gw-ims-org-id']`,
+      // eslint-disable-next-line quotes
+      importCode: `const { AEMHeadless } = require('@adobe/aem-headless-client-nodejs')`,
+      responseCode: `// initialize sdk
+    const aemHeadlessClient = new AEMHeadless({
+      serviceURL: 'http://localhost:4502',
+      endpoint: 'content/graphql/endpoint.gql',
+      auth: ['admin', 'admin']
+    })
+    const queryString = \`{
+      adventureList {
+        items {
+          _path
+        }
+      }
+    }\`
+    // call methods, eg runQuery
+    let response;
+    try {
+        response = await aemHeadlessClient.runQuery(queryString)
+    } catch (e) {
+        console.error(e.toJSON())
+    }`
+    }
+  }
+
+  async prompting () {
+    this.props.actionName = await this.promptForActionName('interacts with the AEMHeadlessClient', 'aem-headless-client')
+  }
+
+  writing () {
+    this.sourceRoot(path.join(__dirname, '.'))
+
+    this.addAction(this.props.actionName, '../../common-templates/stub-action.js', {
+      testFile: './templates/runQuery.test.js',
+      sharedLibFile: '../../common-templates/utils.js',
+      sharedLibTestFile: '../../common-templates/utils.test.js',
+      e2eTestFile: '../../common-templates/stub-action.e2e.js',
+      tplContext: this.props,
+      dependencies: {
+        '@adobe/aem-headless-client-nodejs': '1.1.0'
+      },
+      actionManifestConfig: {
+        inputs: { LOG_LEVEL: 'debug' },
+        annotations: { final: true } // makes sure loglevel cannot be overwritten by request param
+      }
+    })
+  }
+}
+
+module.exports = AemHeadlessClientGenerator

--- a/generators/add-action/aem-headless-client/index.js
+++ b/generators/add-action/aem-headless-client/index.js
@@ -18,7 +18,7 @@ class AemHeadlessClientGenerator extends ActionGenerator {
     this.props = {
       description: 'This is a sample action showcasing how to use AEM GraphQL capabilities',
       // eslint-disable-next-line quotes
-      requiredParams: `['serviceURL', 'endpoint', 'AEM_AUTH']`,
+      requiredParams: `['serviceURL', 'endpoint']`,
       // eslint-disable-next-line quotes
       requiredHeaders: `['Authorization']`,
       // eslint-disable-next-line quotes

--- a/generators/add-action/aem-headless-client/index.js
+++ b/generators/add-action/aem-headless-client/index.js
@@ -53,7 +53,7 @@ class AemHeadlessClientGenerator extends ActionGenerator {
     this.sourceRoot(path.join(__dirname, '.'))
 
     this.addAction(this.props.actionName, '../../common-templates/stub-action.js', {
-      testFile: './templates/runQuery.test.js',
+      testFile: './templates/listPersistedQueries.test.js',
       sharedLibFile: '../../common-templates/utils.js',
       sharedLibTestFile: '../../common-templates/utils.test.js',
       e2eTestFile: '../../common-templates/stub-action.e2e.js',

--- a/generators/add-action/aem-headless-client/templates/listPersistedQueries.test.js
+++ b/generators/add-action/aem-headless-client/templates/listPersistedQueries.test.js
@@ -23,15 +23,15 @@ jest.mock('@adobe/aem-headless-client-nodejs', () => ({
 }))
 const { Core } = require('@adobe/aio-sdk')
 const { AEMHeadless } = require('@adobe/aem-headless-client-nodejs')
-const mockRunQueryInstance = { runQuery: jest.fn() }
+const mockListPersistedQueriesInstance = { listPersistedQueries: jest.fn() }
 const mockLoggerInstance = { info: jest.fn(), debug: jest.fn(), error: jest.fn() }
 Core.Logger.mockReturnValue(mockLoggerInstance)
-const sdk = new AEMHeadless.mockResolvedValue(mockRunQueryInstance)
+const sdk = new AEMHeadless.mockResolvedValue(mockListPersistedQueriesInstance)
 
 const action = require('./<%= actionRelPath %>')
 
 beforeEach(() => {
-  sdk.runQuery.mockReset() // clears calls + mock implementation
+  sdk.listPersistedQueries.mockReset() // clears calls + mock implementation
 
   Core.Logger.mockClear()
   mockLoggerInstance.info.mockReset()
@@ -49,7 +49,7 @@ describe('<%= actionName %>', () => {
   })
   test('should return an http response with AEMHeadless results', async () => {
     const fakeResponse = { fakeHash: {} }
-    sdk.runQuery.mockResolvedValue(fakeResponse)
+    sdk.listPersistedQueries.mockResolvedValue(fakeResponse)
     const response = await action.main(fakeRequestParams)
     expect(response).toEqual({
       statusCode: 200,
@@ -58,7 +58,7 @@ describe('<%= actionName %>', () => {
   })
   test('if there is an error should return a 500 and log the error', async () => {
     const fakeError = new Error('fake')
-    sdk.runQuery.mockRejectedValue(fakeError)
+    sdk.listPersistedQueries.mockRejectedValue(fakeError)
     const response = await action.main(fakeRequestParams)
     expect(response).toEqual({
       error: {

--- a/generators/add-action/aem-headless-client/templates/runQuery.test.js
+++ b/generators/add-action/aem-headless-client/templates/runQuery.test.js
@@ -14,12 +14,13 @@ governing permissions and limitations under the License.
 jest.mock('@adobe/aio-sdk', () => ({
   Core: {
     Logger: jest.fn()
-  },
-  AEMHeadlessClient: {
+  }
+}))
+jest.mock('@adobe/aem-headless-client-nodejs', () => ({
+  AEMHeadless: {
     constructor: jest.fn()
   }
 }))
-
 const { Core } = require('@adobe/aio-sdk')
 const { AEMHeadless } = require('@adobe/aem-headless-client-nodejs')
 const mockRunQueryInstance = { runQuery: jest.fn() }
@@ -37,7 +38,7 @@ beforeEach(() => {
   mockLoggerInstance.debug.mockReset()
   mockLoggerInstance.error.mockReset()
 })
-const fakeRequestParams = { tenant: 'fakeId', apiKey: 'fakeKey', __ow_headers: { authorization: 'Bearer fakeToken', 'x-gw-ims-org-id': 'fakeOrgId' } }
+const fakeRequestParams = { serviceURL: 'fakeServiceURL', endpoint: 'fakEndpoint', __ow_headers: { authorization: 'Bearer fakeToken', 'x-gw-ims-org-id': 'fakeOrgId' } }
 describe('<%= actionName %>', () => {
   test('main should be defined', () => {
     expect(action.main).toBeInstanceOf(Function)
@@ -46,7 +47,7 @@ describe('<%= actionName %>', () => {
     await action.main({ ...fakeRequestParams, LOG_LEVEL: 'fakeLevel' })
     expect(Core.Logger).toHaveBeenCalledWith(expect.any(String), { level: 'fakeLevel' })
   })
-  test('should return an http response with CustomerProfile API profile', async () => {
+  test('should return an http response with AEMHeadless results', async () => {
     const fakeResponse = { fakeHash: {} }
     sdk.runQuery.mockResolvedValue(fakeResponse)
     const response = await action.main(fakeRequestParams)

--- a/generators/add-action/aem-headless-client/templates/runQuery.test.js
+++ b/generators/add-action/aem-headless-client/templates/runQuery.test.js
@@ -1,0 +1,79 @@
+/*<% if (false) { %>
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+<% } %>
+* <license header>
+*/
+
+jest.mock('@adobe/aio-sdk', () => ({
+  Core: {
+    Logger: jest.fn()
+  },
+  AEMHeadlessClient: {
+    constructor: jest.fn()
+  }
+}))
+
+const { Core } = require('@adobe/aio-sdk')
+const { AEMHeadless } = require('@adobe/aem-headless-client-nodejs')
+const mockRunQueryInstance = { runQuery: jest.fn() }
+const mockLoggerInstance = { info: jest.fn(), debug: jest.fn(), error: jest.fn() }
+Core.Logger.mockReturnValue(mockLoggerInstance)
+const sdk = new AEMHeadless.mockResolvedValue(mockRunQueryInstance)
+
+const action = require('./<%= actionRelPath %>')
+
+beforeEach(() => {
+  sdk.runQuery.mockReset() // clears calls + mock implementation
+
+  Core.Logger.mockClear()
+  mockLoggerInstance.info.mockReset()
+  mockLoggerInstance.debug.mockReset()
+  mockLoggerInstance.error.mockReset()
+})
+const fakeRequestParams = { tenant: 'fakeId', apiKey: 'fakeKey', __ow_headers: { authorization: 'Bearer fakeToken', 'x-gw-ims-org-id': 'fakeOrgId' } }
+describe('<%= actionName %>', () => {
+  test('main should be defined', () => {
+    expect(action.main).toBeInstanceOf(Function)
+  })
+  test('should set logger to use LOG_LEVEL param', async () => {
+    await action.main({ ...fakeRequestParams, LOG_LEVEL: 'fakeLevel' })
+    expect(Core.Logger).toHaveBeenCalledWith(expect.any(String), { level: 'fakeLevel' })
+  })
+  test('should return an http response with CustomerProfile API profile', async () => {
+    const fakeResponse = { fakeHash: {} }
+    sdk.runQuery.mockResolvedValue(fakeResponse)
+    const response = await action.main(fakeRequestParams)
+    expect(response).toEqual({
+      statusCode: 200,
+      body: fakeResponse
+    })
+  })
+  test('if there is an error should return a 500 and log the error', async () => {
+    const fakeError = new Error('fake')
+    sdk.runQuery.mockRejectedValue(fakeError)
+    const response = await action.main(fakeRequestParams)
+    expect(response).toEqual({
+      error: {
+        statusCode: 500,
+        body: { error: 'server error' }
+      }
+    })
+    expect(mockLoggerInstance.error).toHaveBeenCalledWith(fakeError)
+  })
+  test('missing input request parameters, should return 400', async () => {
+    const response = await action.main({})
+    expect(response).toEqual({
+      error: {
+        statusCode: 400,
+        body: { error: 'missing header(s) \'authorization,x-gw-ims-org-id\' and missing parameter(s) \'tenant,apiKey,entityId,entityIdNS\'' }
+      }
+    })
+  })
+})

--- a/generators/add-action/index.js
+++ b/generators/add-action/index.js
@@ -25,7 +25,8 @@ const sdkCodeToActionGenerator = {
   [sdkCodes.campaign]: path.join(__dirname, 'campaign-standard/index.js'),
   [sdkCodes.assetCompute]: path.join(__dirname, 'asset-compute/index.js'),
   [sdkCodes.customerProfile]: path.join(__dirname, 'customer-profile/index.js'),
-  [sdkCodes.audienceManagerCD]: path.join(__dirname, 'audience-manager-cd/index.js')
+  [sdkCodes.audienceManagerCD]: path.join(__dirname, 'audience-manager-cd/index.js'),
+  [sdkCodes.AEMHeadlessClient]: path.join(__dirname, 'aem-headless-client/index.js')
 }
 
 const sdkCodeToTitle = {
@@ -34,7 +35,8 @@ const sdkCodeToTitle = {
   [sdkCodes.campaign]: 'Adobe Campaign Standard',
   [sdkCodes.assetCompute]: 'Adobe Asset Compute Worker',
   [sdkCodes.customerProfile]: 'Adobe Experience Platform: Realtime Customer Profile',
-  [sdkCodes.audienceManagerCD]: 'Adobe Audience Manager: Customer Data'
+  [sdkCodes.audienceManagerCD]: 'Adobe Audience Manager: Customer Data',
+  [sdkCodes.AEMHeadlessClient]: 'AEM Headless Client'
 }
 
 const genericActionGenerator = path.join(__dirname, 'generic/index.js')

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -9,7 +9,8 @@ module.exports = {
     campaign: 'CampaignSDK',
     customerProfile: 'McDataServicesSdk',
     target: 'AdobeTargetSDK',
-    audienceManagerCD: 'AudienceManagerCustomerSDK'
+    audienceManagerCD: 'AudienceManagerCustomerSDK',
+    AEMHeadlessClient: 'AEMHeadlessClient'
   },
   ciDirName: '.github',
   commonDependencyVersions: {

--- a/test/generators/add-action/aem-headless-client.test.js
+++ b/test/generators/add-action/aem-headless-client.test.js
@@ -1,0 +1,177 @@
+/* eslint-disable jest/expect-expect */
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const helpers = require('yeoman-test')
+const assert = require('yeoman-assert')
+const fs = require('fs')
+const yaml = require('js-yaml')
+const path = require('path')
+const { EOL } = require('os')
+const cloneDeep = require('lodash.clonedeep')
+
+const theGeneratorPath = require.resolve('../../../generators/add-action/aem-headless-client')
+const Generator = require('yeoman-generator')
+
+const constants = require('../../../lib/constants')
+
+describe('prototype', () => {
+  test('exports a yeoman generator', () => {
+    expect(require(theGeneratorPath).prototype).toBeInstanceOf(Generator)
+  })
+})
+
+function assertGeneratedFiles (actionName) {
+  assert.file(`${constants.actionsDirname}/${actionName}/index.js`)
+
+  assert.file(`test/${actionName}.test.js`)
+  assert.file(`e2e/${actionName}.e2e.test.js`)
+
+  assert.file(`${constants.actionsDirname}/utils.js`)
+  assert.file('test/utils.test.js')
+
+  assert.file('ext.config.yaml')
+  assert.file('.env')
+}
+
+// pkgName is optional
+function assertManifestContent (actionName, pkgName) {
+  const json = yaml.safeLoad(fs.readFileSync('ext.config.yaml').toString())
+  expect(json.runtimeManifest.packages).toBeDefined()
+
+  // default packageName is path.basename(path.dirname('ext.config.yaml'))
+  pkgName = pkgName || path.basename(process.cwd())
+
+  expect(json.runtimeManifest.packages[pkgName].actions[actionName]).toEqual({
+    function: `${constants.actionsDirname}/${actionName}/index.js`,
+    web: 'yes',
+    runtime: 'nodejs:14',
+    inputs: {
+      LOG_LEVEL: 'debug',
+      AEM_AUTH: '$AEM_AUTH'
+    },
+    annotations: {
+      final: true,
+      'require-adobe-auth': true
+    }
+  })
+}
+
+function assertEnvContent (prevContent) {
+  assert.fileContent('.env', `## please provide your AEM Auth: service token path, dev token, or [user,pass]${EOL}#AEM_AUTH=`)
+  assert.fileContent('.env', prevContent)
+}
+
+function assertActionCodeContent (actionName) {
+  const theFile = `${constants.actionsDirname}/${actionName}/index.js`
+  // a few checks to make sure the action calls the sdk
+  assert.fileContent(
+    theFile,
+    `const { Core } = require('@adobe/aio-sdk')
+    const { AEMHeadless } = require('@adobe/aem-headless-client-nodejs')`
+  )
+  assert.fileContent(
+    theFile,
+    'const requiredParams = [\'serviceURL\', \'endpoint\']'
+  )
+  assert.fileContent(
+    theFile,
+    'const requiredHeaders = [\'Authorization\']'
+  )
+  assert.fileContent(
+    theFile,
+    `const auth = params.AEM_AUTH && params.AEM_AUTH[0] === '[' ? JSON.parse(params.AEM_AUTH) : params.AEM_AUTH
+    const aemHeadlessClient = new AEMHeadless({
+      serviceURL: params.serviceURL,
+      endpoint: params.endpoint,
+      auth
+    })`
+  )
+  assert.fileContent(
+    theFile,
+    'const body = await aemHeadlessClient.listPersistedQueries()'
+  )
+}
+
+describe('run', () => {
+  test('--skip-prompt', async () => {
+    const options = cloneDeep(global.basicGeneratorOptions)
+    options['skip-prompt'] = true
+    const prevDotEnvContent = `PREVIOUSCONTENT${EOL}`
+    await helpers.run(theGeneratorPath)
+      .withOptions(options)
+      .inTmpDir(dir => {
+        fs.writeFileSync(path.join(dir, '.env'), prevDotEnvContent)
+      })
+
+    // default
+    const actionName = 'aem-headless-client'
+
+    assertGeneratedFiles(actionName)
+    assertActionCodeContent(actionName)
+    assertManifestContent(actionName)
+    assertEnvContent(prevDotEnvContent)
+    assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String), '@adobe/aem-headless-client-nodejs': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
+  })
+
+  test('--skip-prompt, and action with default name already exists', async () => {
+    const options = cloneDeep(global.basicGeneratorOptions)
+    options['skip-prompt'] = true
+    const prevDotEnvContent = `PREVIOUSCONTENT${EOL}`
+    await helpers.run(theGeneratorPath)
+      .withOptions(options)
+      .inTmpDir(dir => {
+        fs.writeFileSync('ext.config.yaml', yaml.dump({
+          runtimeManifest: {
+            packages: {
+              somepackage: {
+                actions: {
+                  'aem-headless-client': { function: 'fake.js' }
+                }
+              }
+            }
+          }
+        }))
+        fs.writeFileSync(path.join(dir, '.env'), prevDotEnvContent)
+      })
+
+    // default
+    const actionName = 'aem-headless-client-1'
+    assertGeneratedFiles(actionName)
+    assertActionCodeContent(actionName)
+    assertManifestContent(actionName, 'somepackage')
+    assertEnvContent(prevDotEnvContent)
+    assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String), '@adobe/aem-headless-client-nodejs': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
+  })
+
+  test('user input actionName=fakeAction', async () => {
+    const options = cloneDeep(global.basicGeneratorOptions)
+    options['skip-prompt'] = false
+    const prevDotEnvContent = `PREVIOUSCONTENT${EOL}`
+    await helpers.run(theGeneratorPath)
+      .withOptions(options)
+      .withPrompts({ actionName: 'fakeAction' })
+      .inTmpDir(dir => {
+        fs.writeFileSync(path.join(dir, '.env'), prevDotEnvContent)
+      })
+
+    const actionName = 'fakeAction'
+
+    assertGeneratedFiles(actionName)
+    assertActionCodeContent(actionName)
+    assertManifestContent(actionName)
+    assertEnvContent(prevDotEnvContent)
+    assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String), '@adobe/aem-headless-client-nodejs': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
+    assertNodeEngines(fs, '^10 || ^12 || ^14')
+  })
+})

--- a/test/generators/add-action/aem-headless-client.test.js
+++ b/test/generators/add-action/aem-headless-client.test.js
@@ -75,8 +75,11 @@ function assertActionCodeContent (actionName) {
   // a few checks to make sure the action calls the sdk
   assert.fileContent(
     theFile,
-    `const { Core } = require('@adobe/aio-sdk')
-    const { AEMHeadless } = require('@adobe/aem-headless-client-nodejs')`
+    'const { Core } = require(\'@adobe/aio-sdk\')'
+  )
+  assert.fileContent(
+    theFile,
+    'const { AEMHeadless } = require(\'@adobe/aem-headless-client-nodejs\')'
   )
   assert.fileContent(
     theFile,
@@ -88,16 +91,15 @@ function assertActionCodeContent (actionName) {
   )
   assert.fileContent(
     theFile,
-    `const auth = params.AEM_AUTH && params.AEM_AUTH[0] === '[' ? JSON.parse(params.AEM_AUTH) : params.AEM_AUTH
-    const aemHeadlessClient = new AEMHeadless({
-      serviceURL: params.serviceURL,
-      endpoint: params.endpoint,
-      auth
-    })`
+    'const aemHeadlessClient = new AEMHeadless({\n' +
+    '        serviceURL: params.serviceURL,\n' +
+    '        endpoint: params.endpoint,\n' +
+    '        auth\n' +
+    '      })'
   )
   assert.fileContent(
     theFile,
-    'const body = await aemHeadlessClient.listPersistedQueries()'
+    'body = await aemHeadlessClient.listPersistedQueries()'
   )
 }
 
@@ -119,7 +121,7 @@ describe('run', () => {
     assertActionCodeContent(actionName)
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
-    assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String), '@adobe/aem-headless-client-nodejs': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
+    assertDependencies(fs, { '@adobe/aem-headless-client-nodejs': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
     assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
@@ -150,7 +152,7 @@ describe('run', () => {
     assertActionCodeContent(actionName)
     assertManifestContent(actionName, 'somepackage')
     assertEnvContent(prevDotEnvContent)
-    assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String), '@adobe/aem-headless-client-nodejs': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
+    assertDependencies(fs, { '@adobe/aem-headless-client-nodejs': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
     assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 
@@ -171,7 +173,7 @@ describe('run', () => {
     assertActionCodeContent(actionName)
     assertManifestContent(actionName)
     assertEnvContent(prevDotEnvContent)
-    assertDependencies(fs, { '@adobe/aio-sdk': expect.any(String), '@adobe/aem-headless-client-nodejs': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
+    assertDependencies(fs, { '@adobe/aem-headless-client-nodejs': expect.any(String) }, { '@openwhisk/wskdebug': expect.any(String) })
     assertNodeEngines(fs, '^10 || ^12 || ^14')
   })
 })

--- a/test/generators/add-action/index.test.js
+++ b/test/generators/add-action/index.test.js
@@ -49,6 +49,10 @@ const expectedChoices = {
   [sdkCodes.audienceManagerCD]: {
     name: 'Adobe Audience Manager: Customer Data',
     value: expect.stringContaining(path.normalize('audience-manager-cd/index.js'))
+  },
+  [sdkCodes.AEMHeadlessClient]: {
+    name: 'AEM Headless Client',
+    value: expect.stringContaining(path.normalize('aem-headless-client/index.js'))
   }
 }
 
@@ -76,10 +80,10 @@ describe('prototype', () => {
 })
 
 describe('run', () => {
-  test('--skip-prompt --adobe-services="analytics,target,campaign-standard,customer-profile"', async () => {
+  test('--skip-prompt --adobe-services="analytics,target,campaign-standard,customer-profile,aem-headless-client"', async () => {
     const options = cloneDeep(global.basicGeneratorOptions)
     options['skip-prompt'] = true
-    options['adobe-services'] = `${sdkCodes.analytics},${sdkCodes.target},${sdkCodes.campaign},${sdkCodes.customerProfile}`
+    options['adobe-services'] = `${sdkCodes.analytics},${sdkCodes.target},${sdkCodes.campaign},${sdkCodes.customerProfile},${sdkCodes.AEMHeadlessClient}`
     await helpers.run(theGeneratorPath)
       .withOptions(options)
     // with skip prompt defaults to generic action
@@ -108,7 +112,8 @@ describe('run', () => {
           { ...expectedChoices[sdkCodes.campaign], checked: false },
           { ...expectedChoices[sdkCodes.customerProfile], checked: false },
           { ...expectedChoices[sdkCodes.target], checked: false },
-          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: false }
+          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: false },
+          { ...expectedChoices[sdkCodes.AEMHeadlessClient], checked: false }
         ]
       })
     ])
@@ -135,7 +140,8 @@ describe('run', () => {
           { ...expectedChoices[sdkCodes.campaign], checked: false },
           { ...expectedChoices[sdkCodes.customerProfile], checked: false },
           { ...expectedChoices[sdkCodes.target], checked: false },
-          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: false }
+          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: false },
+          { ...expectedChoices[sdkCodes.AEMHeadlessClient], checked: false }
         ]
       })
     ])
@@ -166,7 +172,8 @@ describe('run', () => {
           { ...expectedChoices[sdkCodes.campaign], checked: false },
           { ...expectedChoices[sdkCodes.customerProfile], checked: false },
           { ...expectedChoices[sdkCodes.target], checked: false },
-          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: false }
+          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: false },
+          { ...expectedChoices[sdkCodes.AEMHeadlessClient], checked: false }
         ]
       })
     ])
@@ -197,7 +204,8 @@ describe('run', () => {
           { ...expectedChoices[sdkCodes.assetCompute], checked: false },
           { ...expectedChoices[sdkCodes.campaign], checked: false },
           { ...expectedChoices[sdkCodes.target], checked: false },
-          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: false }
+          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: false },
+          { ...expectedChoices[sdkCodes.AEMHeadlessClient], checked: false }
         ]
       })
     ])
@@ -230,7 +238,8 @@ describe('run', () => {
           { ...expectedChoices[sdkCodes.target], checked: false },
           expectedSeparator,
           { ...expectedChoices[sdkCodes.campaign], checked: false },
-          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: false }
+          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: false },
+          { ...expectedChoices[sdkCodes.AEMHeadlessClient], checked: false }
         ]
       })
     ])
@@ -243,7 +252,7 @@ describe('run', () => {
   test('--adobe-services="analytics,customerProfile", supported-adobe-services=ALL', async () => {
     const options = cloneDeep(global.basicGeneratorOptions)
     options['adobe-services'] = `${sdkCodes.analytics},${sdkCodes.customerProfile}`
-    options['supported-adobe-services'] = `${sdkCodes.analytics},${sdkCodes.assetCompute},${sdkCodes.customerProfile},${sdkCodes.campaign},${sdkCodes.target},${sdkCodes.audienceManagerCD}`
+    options['supported-adobe-services'] = `${sdkCodes.analytics},${sdkCodes.assetCompute},${sdkCodes.customerProfile},${sdkCodes.campaign},${sdkCodes.target},${sdkCodes.audienceManagerCD},${sdkCodes.AEMHeadlessClient}`
     await helpers.run(theGeneratorPath)
       .withOptions(options)
       .withPrompts({ actionGenerators: ['a', 'b', 'c'] })
@@ -263,7 +272,8 @@ describe('run', () => {
           { ...expectedChoices[sdkCodes.assetCompute], checked: false },
           { ...expectedChoices[sdkCodes.campaign], checked: false },
           { ...expectedChoices[sdkCodes.target], checked: false },
-          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: false }
+          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: false },
+          { ...expectedChoices[sdkCodes.AEMHeadlessClient], checked: false }
         ]
       })
     ])
@@ -275,8 +285,8 @@ describe('run', () => {
 
   test('--adobe-services=ALL, supported-adobe-services=ALL', async () => {
     const options = cloneDeep(global.basicGeneratorOptions)
-    options['adobe-services'] = `${sdkCodes.analytics},${sdkCodes.assetCompute},${sdkCodes.customerProfile},${sdkCodes.campaign},${sdkCodes.target},${sdkCodes.audienceManagerCD}`
-    options['supported-adobe-services'] = `${sdkCodes.analytics},${sdkCodes.assetCompute},${sdkCodes.customerProfile},${sdkCodes.campaign},${sdkCodes.target},${sdkCodes.audienceManagerCD}`
+    options['adobe-services'] = `${sdkCodes.analytics},${sdkCodes.assetCompute},${sdkCodes.customerProfile},${sdkCodes.campaign},${sdkCodes.target},${sdkCodes.audienceManagerCD},${sdkCodes.AEMHeadlessClient}`
+    options['supported-adobe-services'] = `${sdkCodes.analytics},${sdkCodes.assetCompute},${sdkCodes.customerProfile},${sdkCodes.campaign},${sdkCodes.target},${sdkCodes.audienceManagerCD},${sdkCodes.AEMHeadlessClient}`
     await helpers.run(theGeneratorPath)
       .withOptions(options)
       .withPrompts({ actionGenerators: ['a', 'b', 'c'] })
@@ -295,7 +305,8 @@ describe('run', () => {
           { ...expectedChoices[sdkCodes.customerProfile], checked: true },
           { ...expectedChoices[sdkCodes.campaign], checked: true },
           { ...expectedChoices[sdkCodes.target], checked: true },
-          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: true }
+          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: true },
+          { ...expectedChoices[sdkCodes.AEMHeadlessClient], checked: true }
         ]
       })
     ])
@@ -307,10 +318,10 @@ describe('run', () => {
 
   test('--adobe-services=ALL', async () => {
     const options = cloneDeep(global.basicGeneratorOptions)
-    options['adobe-services'] = `${sdkCodes.analytics},${sdkCodes.assetCompute},${sdkCodes.customerProfile},${sdkCodes.campaign},${sdkCodes.target},${sdkCodes.audienceManagerCD}`
+    options['adobe-services'] = `${sdkCodes.analytics},${sdkCodes.assetCompute},${sdkCodes.customerProfile},${sdkCodes.campaign},${sdkCodes.target},${sdkCodes.audienceManagerCD},${sdkCodes.AEMHeadlessClient}`
     await helpers.run(theGeneratorPath)
       .withOptions({
-        'adobe-services': `${sdkCodes.analytics},${sdkCodes.assetCompute},${sdkCodes.customerProfile},${sdkCodes.campaign},${sdkCodes.target},${sdkCodes.audienceManagerCD}`
+        'adobe-services': `${sdkCodes.analytics},${sdkCodes.assetCompute},${sdkCodes.customerProfile},${sdkCodes.campaign},${sdkCodes.target},${sdkCodes.audienceManagerCD},${sdkCodes.AEMHeadlessClient}`
       })
       .withPrompts({ actionGenerators: ['a', 'b', 'c'] })
 
@@ -328,7 +339,8 @@ describe('run', () => {
           { ...expectedChoices[sdkCodes.customerProfile], checked: true },
           { ...expectedChoices[sdkCodes.campaign], checked: true },
           { ...expectedChoices[sdkCodes.target], checked: true },
-          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: true }
+          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: true },
+          { ...expectedChoices[sdkCodes.AEMHeadlessClient], checked: true }
         ]
       })
     ])
@@ -362,7 +374,8 @@ describe('run', () => {
           { ...expectedChoices[sdkCodes.target], checked: false },
           expectedSeparator,
           { ...expectedChoices[sdkCodes.campaign], checked: false },
-          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: false }
+          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: false },
+          { ...expectedChoices[sdkCodes.AEMHeadlessClient], checked: false }
         ]
       })
     ])
@@ -375,7 +388,7 @@ describe('run', () => {
   test('--adobe-services="", supported-adobe-services=ALL', async () => {
     const options = cloneDeep(global.basicGeneratorOptions)
     options['adobe-services'] = ''
-    options['supported-adobe-services'] = `${sdkCodes.analytics},${sdkCodes.assetCompute},${sdkCodes.customerProfile},${sdkCodes.campaign},${sdkCodes.target},${sdkCodes.audienceManagerCD}`
+    options['supported-adobe-services'] = `${sdkCodes.analytics},${sdkCodes.assetCompute},${sdkCodes.customerProfile},${sdkCodes.campaign},${sdkCodes.target},${sdkCodes.audienceManagerCD},${sdkCodes.AEMHeadlessClient}`
     await helpers.run(theGeneratorPath)
       .withOptions(options)
       .withPrompts({ actionGenerators: ['a', 'b', 'c'] })
@@ -395,7 +408,8 @@ describe('run', () => {
           { ...expectedChoices[sdkCodes.customerProfile], checked: false },
           { ...expectedChoices[sdkCodes.campaign], checked: false },
           { ...expectedChoices[sdkCodes.target], checked: false },
-          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: false }
+          { ...expectedChoices[sdkCodes.audienceManagerCD], checked: false },
+          { ...expectedChoices[sdkCodes.AEMHeadlessClient], checked: false }
         ]
       })
     ])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added action generator for AEM Headless Client 
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/adobe/aem-headless-client-nodejs/issues/2
https://github.com/adobe/generator-aio-app/issues/186
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests
Tested with demo project for aio action using remote AEMaaCS with basic auth

## Screenshots (if appropriate):
<img width="1414" alt="Screenshot 2022-03-06 at 01 23 20" src="https://user-images.githubusercontent.com/2750284/156904085-1c897194-517f-441a-accf-0595848bb5ea.png">

## Types of changes
Added action generator for AEM Headless Client https://github.com/adobe/aem-headless-client-nodejs/issues/2
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
