### PR TITLE
Revert "fix: remove runtime apihost from base-app env (#190)"

### DIFF
--- a/generators/base-app/templates/_dot.env
+++ b/generators/base-app/templates/_dot.env
@@ -5,5 +5,6 @@
 ## Adobe I/O Runtime credentials
 AIO_runtime_auth=''
 AIO_runtime_namespace=''
+AIO_runtime_apihost='https://adobeioruntime.net'
 ## Adobe I/O Console service account credentials (JWT) Api Key
 SERVICE_API_KEY=''


### PR DESCRIPTION
This reverts commit 811dc191f8afab772f001ebcb7aa1ade1ae9b132.

## Description

`AIO_runtime_apihost` is read by `wskdebug` to get openwhisk server runtime docker image data, so it is a necessary part of the environment configuration for a base app if we want to support local debugging. 

## Related Issue

https://github.com/adobe/aio-cli-plugin-app/issues/541

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
