### PR TITLE
Generate web or actions keys in app.config.yaml only when necessary

### DIFF
--- a/generators/application/index.js
+++ b/generators/application/index.js
@@ -44,16 +44,22 @@ class Application extends Generator {
     this.webSrcFolder = path.join(this.appFolder, 'web-src')
     this.configPath = path.join(this.appFolder, 'app.config.yaml')
     this.keyToManifest = 'application.' + runtimeManifestKey
+    this.components = ['actions', 'events', 'webAssets'] // defaults when skip prompt
   }
 
   async writing () {
-    // add basic config to point to path, relative to config file
-    utils.writeKeyAppConfig(this, 'application.actions', path.relative(this.appFolder, this.actionFolder))
-    utils.writeKeyAppConfig(this, 'application.web', path.relative(this.appFolder, this.webSrcFolder))
+    // add path to actions in app.config.yaml
+    if (this.components.includes('actions')) {
+      utils.writeKeyAppConfig(this, 'application.actions', path.relative(this.appFolder, this.actionFolder))
+    }
+
+    // add path to web assets in app.config.yaml
+    if (this.components.includes('webAssets')) {
+      utils.writeKeyAppConfig(this, 'application.web', path.relative(this.appFolder, this.webSrcFolder))
+    }
   }
 
   async composeWithAddGenerators () {
-    let components = ['actions', 'events', 'webAssets'] // defaults when skip prompt
     if (!this.options['skip-prompt']) {
       const res = await this.prompt([
         {
@@ -81,11 +87,11 @@ class Application extends Generator {
           validate: utils.atLeastOne
         }
       ])
-      components = res.components
+      this.components = res.components
     }
-    const addActions = components.includes('actions')
-    const addEvents = components.includes('events')
-    const addWebAssets = components.includes('webAssets')
+    const addActions = this.components.includes('actions')
+    const addEvents = this.components.includes('events')
+    const addWebAssets = this.components.includes('webAssets')
 
     // TODO cleanup unecessary params in all generators
     // run add action and add ui generators when applicable

--- a/test/generators/application/index.test.js
+++ b/test/generators/application/index.test.js
@@ -15,17 +15,22 @@ const helpers = require('yeoman-test')
 
 const theGeneratorPath = require.resolve('../../../generators/application')
 const Generator = require('yeoman-generator')
+const { utils } = require('@adobe/generator-app-common-lib')
 
 // spies
 const composeWith = jest.spyOn(Generator.prototype, 'composeWith')
+const writeKeyAppConfig = jest.spyOn(utils, 'writeKeyAppConfig')
 beforeAll(() => {
   composeWith.mockReturnValue(undefined)
+  writeKeyAppConfig.mockReturnValue(undefined)
 })
 beforeEach(() => {
   composeWith.mockClear()
+  writeKeyAppConfig.mockClear()
 })
 afterAll(() => {
   composeWith.mockRestore()
+  writeKeyAppConfig.mockRestore()
 })
 
 jest.mock('@adobe/generator-app-common-lib', () => ({
@@ -51,6 +56,10 @@ describe('run', () => {
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-action/index.js')), expect.any(Object))
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-events/index.js')), expect.any(Object))
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-web-assets/index.js')), expect.any(Object))
+
+    expect(writeKeyAppConfig).toHaveBeenCalledTimes(2)
+    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(Generator), expect.stringContaining('application.actions'), 'actions')
+    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(Generator), expect.stringContaining('application.web'), 'web-src')
   })
 
   test('--skip-prompt --adobe-services some,string', async () => {
@@ -61,6 +70,10 @@ describe('run', () => {
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-web-assets/index.js')), expect.any(Object))
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-action/index.js')), expect.any(Object))
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-events/index.js')), expect.any(Object))
+
+    expect(writeKeyAppConfig).toHaveBeenCalledTimes(2)
+    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(Generator), expect.stringContaining('application.actions'), 'actions')
+    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(Generator), expect.stringContaining('application.web'), 'web-src')
   })
 
   test('--adobe-services some,string --supported-adobe-services="" and prompt selection "actions"', async () => {
@@ -70,6 +83,9 @@ describe('run', () => {
 
     expect(composeWith).toHaveBeenCalledTimes(1)
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-action/index.js')), expect.any(Object))
+
+    expect(writeKeyAppConfig).toHaveBeenCalledTimes(1)
+    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(Generator), expect.stringContaining('application.actions'), 'actions')
   })
 
   test('--adobe-services some,string and prompt selection "events"', async () => {
@@ -79,6 +95,8 @@ describe('run', () => {
 
     expect(composeWith).toHaveBeenCalledTimes(1)
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-events/index.js')), expect.any(Object))
+
+    expect(writeKeyAppConfig).toHaveBeenCalledTimes(0)
   })
 
   test('--adobe-services some,string and prompt selection "web-assets"', async () => {
@@ -88,6 +106,9 @@ describe('run', () => {
 
     expect(composeWith).toHaveBeenCalledTimes(1)
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-web-assets/index.js')), expect.any(Object))
+
+    expect(writeKeyAppConfig).toHaveBeenCalledTimes(1)
+    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(Generator), expect.stringContaining('application.web'), 'web-src')
   })
   test('--adobe-services some,string --supported-adobe-service=some,other,string and prompt selection "web-assets, actions"', async () => {
     await helpers.run(theGeneratorPath)
@@ -97,6 +118,10 @@ describe('run', () => {
     expect(composeWith).toHaveBeenCalledTimes(2)
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-action/index.js')), expect.any(Object))
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-web-assets/index.js')), expect.any(Object))
+
+    expect(writeKeyAppConfig).toHaveBeenCalledTimes(2)
+    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(Generator), expect.stringContaining('application.actions'), 'actions')
+    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(Generator), expect.stringContaining('application.web'), 'web-src')
   })
   test('--adobe-services some,string --supported-adobe-service=some,other,string and prompt selection "web-assets, actions, events"', async () => {
     await helpers.run(theGeneratorPath)
@@ -107,6 +132,10 @@ describe('run', () => {
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-action/index.js')), expect.any(Object))
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-web-assets/index.js')), expect.any(Object))
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-events/index.js')), expect.any(Object))
+
+    expect(writeKeyAppConfig).toHaveBeenCalledTimes(2)
+    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(Generator), expect.stringContaining('application.actions'), 'actions')
+    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(Generator), expect.stringContaining('application.web'), 'web-src')
   })
   test('--skip-prompt --skip-install', async () => {
     await helpers.run(theGeneratorPath)
@@ -117,5 +146,9 @@ describe('run', () => {
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-action/index.js')), expect.any(Object))
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-events/index.js')), expect.any(Object))
     expect(composeWith).toHaveBeenCalledWith(expect.stringContaining(path.normalize('add-web-assets/index.js')), expect.any(Object))
+
+    expect(writeKeyAppConfig).toHaveBeenCalledTimes(2)
+    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(Generator), expect.stringContaining('application.actions'), 'actions')
+    expect(writeKeyAppConfig).toHaveBeenCalledWith(expect.any(Generator), expect.stringContaining('application.web'), 'web-src')
   })
 })


### PR DESCRIPTION
This pull request proposes only generating the `web` or `actions` keys in `app.config.yaml` when the user initializes an application with the features associated with those keys. 

## Description

This pull request adds a conditional check during project generation to only add the `web` or `actions` keys in `app.config.yaml` if the user's response to the feature prompt during the `aio app init` command indicates they are needed.

## Related Issue

Closes https://github.com/adobe/aio-cli-plugin-app/issues/555

## Motivation and Context

Remove bloat from configuration. 

## How Has This Been Tested?

`npm run test`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
