### PR TITLE
Deploy in staging should not trigger the publish process

### DIFF
--- a/generators/add-ci/.github/workflows/deploy_stage.yml
+++ b/generators/add-ci/.github/workflows/deploy_stage.yml
@@ -59,3 +59,4 @@ jobs:
         with:
           os: ${{ matrix.os }}
           command: deploy
+          noPublish: true


### PR DESCRIPTION
Deploy to Stage should not trigger the publish process

## Description

GitHub action should make sure user by default do not publish in the stage workspace. If not this will result with the following error:

```
- Getting Extension Points in Workspace=***...
>    Error: [CoreConsoleAPISDK:ERROR_GET_WORKSPACE_ENDPOINTS] 500 - Internal
```

## Motivation and Context

This was reported by a customer.

## How Has This Been Tested?

- Deploy actions now works on GitHub.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
