### PR TITLE
feat: add optional eslint config to base-app

### DIFF
--- a/generators/base-app/templates/_eslintrc.adobe.recommended.json
+++ b/generators/base-app/templates/_eslintrc.adobe.recommended.json
@@ -1,0 +1,11 @@
+{
+    "extends": "@adobe/eslint-config-aio-lib-config",
+    "settings": {
+        "jsdoc": {
+            "ignorePrivate": true
+        }
+    },
+    "parserOptions": {
+        "ecmaVersion": "latest"
+    }
+}

--- a/generators/base-app/templates/_eslintrc.basic.json
+++ b/generators/base-app/templates/_eslintrc.basic.json
@@ -1,0 +1,10 @@
+{
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "extends": ["eslint:recommended", "plugin:jest/recommended"],
+    "parserOptions": {
+        "ecmaVersion": "latest"
+    }
+}

--- a/generators/base-app/templates/package.json
+++ b/generators/base-app/templates/package.json
@@ -9,6 +9,8 @@
   },
   "scripts": {
       "test": "jest --passWithNoTests ./test",
-      "e2e": "jest --collectCoverage=false --testRegex ./e2e"
+      "e2e": "jest --collectCoverage=false --testRegex ./e2e",
+      "lint": "eslint --ignore-pattern web-src --no-error-on-unmatched-pattern test src actions",
+      "lint:fix": "npm run lint -- --fix"
   }
 }

--- a/test/generators/base-app/index.test.js
+++ b/test/generators/base-app/index.test.js
@@ -34,7 +34,81 @@ describe('run', () => {
     expect(ret).toBeDefined()
     ret.assertFile('.env')
     ret.assertFile('.gitignore')
+    ret.assertFile('.eslintrc.json')
+    ret.assertJsonFileContent('package.json',
+      {
+        devDependencies: {
+          eslint: '^8',
+          'eslint-plugin-jest': '^27.2.3'
+        },
+        scripts: { lint: 'eslint --ignore-pattern web-src --no-error-on-unmatched-pattern test src actions' }
+      }
+    )
     ret.assertNoFile('_dot.env')
     ret.assertNoFile('_dot.gitignore')
+    ret.assertNoFile('_eslint.basic.json')
+    ret.assertNoFile('_eslintrc.adobe.recommended.json')
+  })
+
+  test('basic ext generator, no linter', async () => {
+    const options = { 'skip-prompt': true, linter: 'none' }
+
+    const ret = await yeomanTestHelpers.run(theGeneratorPath)
+      .withOptions(options)
+    expect(ret).toBeDefined()
+    ret.assertFile('.env')
+    ret.assertFile('.gitignore')
+    ret.assertNoFile('.eslintrc.json')
+    ret.assertNoJsonFileContent('package.json', { scripts: { lint: 'eslint --ignore-pattern web-src --no-error-on-unmatched-pattern test src actions' } })
+    ret.assertNoFile('_dot.env')
+    ret.assertNoFile('_dot.gitignore')
+    ret.assertNoFile('_eslint.basic.json')
+    ret.assertNoFile('_eslintrc.adobe.recommended.json')
+  })
+
+  test('basic ext generator, adobe recommended linter', async () => {
+    const options = { 'skip-prompt': true, linter: 'adobe-recommended' }
+
+    const ret = await yeomanTestHelpers.run(theGeneratorPath)
+      .withOptions(options)
+    expect(ret).toBeDefined()
+    ret.assertFile('.env')
+    ret.assertFile('.gitignore')
+    ret.assertFile('.eslintrc.json')
+    ret.assertJsonFileContent('package.json',
+      {
+        devDependencies: {
+          '@adobe/eslint-config-aio-lib-config': '^3',
+          'eslint-config-standard': '^17.1.0',
+          'eslint-plugin-import': '^2.28.0',
+          'eslint-plugin-jest': '^27.2.3',
+          'eslint-plugin-jsdoc': '^42.0.0',
+          'eslint-plugin-n': '^15.7',
+          'eslint-plugin-node': '^11.1.0',
+          'eslint-plugin-promise': '^6.1.1'
+        },
+        scripts: { lint: 'eslint --ignore-pattern web-src --no-error-on-unmatched-pattern test src actions' }
+      }
+    )
+    ret.assertNoFile('_dot.env')
+    ret.assertNoFile('_dot.gitignore')
+    ret.assertNoFile('_eslint.basic.json')
+    ret.assertNoFile('_eslintrc.adobe.recommended.json')
+  })
+
+  test('basic ext generator, prompt returns None', async () => {
+    const options = { 'skip-prompt': false, linter: 'none' }
+
+    const ret = await yeomanTestHelpers.run(theGeneratorPath)
+      .withOptions(options)
+    expect(ret).toBeDefined()
+    ret.assertFile('.env')
+    ret.assertFile('.gitignore')
+    ret.assertNoFile('.eslintrc.json')
+    ret.assertNoJsonFileContent('package.json', { scripts: { lint: 'eslint --ignore-pattern web-src --no-error-on-unmatched-pattern test src actions' } })
+    ret.assertNoFile('_dot.env')
+    ret.assertNoFile('_dot.gitignore')
+    ret.assertNoFile('_eslint.basic.json')
+    ret.assertNoFile('_eslintrc.adobe.recommended.json')
   })
 })


### PR DESCRIPTION
## Description

Add optional eslint config to base-app generator, options include: 
- `none` - no linter
- `basic` - eslint:recommended + jest plugin 
- `adobe-recommended` - Adobe's shareable eslint config

## Related Issue

https://github.com/adobe/aio-cli-plugin-app/issues/738

## Motivation and Context

## How Has This Been Tested?

`npm run test`, locally linked plugin

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
