### PR TITLE
feat: update add-ci generator with aio-cli v11.x

### DIFF
--- a/generators/add-ci/.github/workflows/deploy_prod.yml
+++ b/generators/add-ci/.github/workflows/deploy_prod.yml
@@ -25,7 +25,7 @@ jobs:
         uses: adobe/aio-cli-setup-action@1.3.0
         with:
           os: ${{ matrix.os }}
-          version: 10.x.x
+          version: 11.x.x
       - name: Auth
         uses: adobe/aio-apps-action@3.3.0
         with:

--- a/generators/add-ci/.github/workflows/deploy_stage.yml
+++ b/generators/add-ci/.github/workflows/deploy_stage.yml
@@ -26,7 +26,7 @@ jobs:
         uses: adobe/aio-cli-setup-action@1.3.0
         with:
           os: ${{ matrix.os }}
-          version: 10.x.x
+          version: 11.x.x
       - name: Auth
         uses: adobe/aio-apps-action@3.3.0
         with:

--- a/generators/add-ci/.github/workflows/pr_test.yml
+++ b/generators/add-ci/.github/workflows/pr_test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: adobe/aio-cli-setup-action@1.3.0
         with:
           os: ${{ matrix.os }}
-          version: 10.x.x
+          version: 11.x.x
       - name: Auth
         uses: adobe/aio-apps-action@3.3.0
         with:

--- a/test/generators/add-ci/index.test.js
+++ b/test/generators/add-ci/index.test.js
@@ -38,13 +38,13 @@ describe('run', () => {
 
     // added files
     assert.file('.github/workflows/pr_test.yml')
-    assert.fileContent('.github/workflows/pr_test.yml', 'version: 10.x.x')
+    assert.fileContent('.github/workflows/pr_test.yml', 'version: 11.x.x')
     assert.fileContent('.github/workflows/pr_test.yml', 'adobe/aio-apps-action@3.3.0')
     assert.file('.github/workflows/deploy_prod.yml')
-    assert.fileContent('.github/workflows/deploy_prod.yml', 'version: 10.x.x')
+    assert.fileContent('.github/workflows/deploy_prod.yml', 'version: 11.x.x')
     assert.fileContent('.github/workflows/deploy_prod.yml', 'adobe/aio-apps-action@3.3.0')
     assert.file('.github/workflows/deploy_stage.yml')
-    assert.fileContent('.github/workflows/deploy_stage.yml', 'version: 10.x.x')
+    assert.fileContent('.github/workflows/deploy_stage.yml', 'version: 11.x.x')
     assert.fileContent('.github/workflows/deploy_stage.yml', 'adobe/aio-apps-action@3.3.0')
   })
 })


### PR DESCRIPTION
## Description

This requires aio-cli to have a major version release to v11 (already released).

v11 and greater of the aio-cli will support the Deploy Service. Update the CI workflows to use this new version.
There will be a minor version update of this lib to v9.1.0

Note:
Users on older CLIs (v10 and below) may receive this change and their CI workflows will use the updated cli version v11, which will be newer from their existing version. To minimize risk they can decrement the version in the .yml files manually back to 10. If they keep v11, the only thing that will be different is now their CI, with the new CLI version, will output activity logs in Developer Console.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
